### PR TITLE
More descritive information when a problem occurs while connecting to joomla update server

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -120,15 +120,14 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		}
 		try
 		{
-			if (!JUpdater::getInstance()->findUpdates(700, $cache_timeout))
-			{
-				// If the joomla update return nothing, let's see if this is caused by unable to connect to joomla update server.
-				JHttpFactory::getHttp()->get('https://update.joomla.org/');
-			}
+			// Try to connect to Joomla! Update Server. Trows exception if connection not available.
+			JHttpFactory::getHttp()->get('https://update.joomla.org/');
+			// Get Joomla! updates.
+			JUpdater::getInstance()->findUpdates(700, $cache_timeout);
 		}
 		catch (RuntimeException $e)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION'), 'info');
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION'), 'warning');
 		}
 	}
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -118,10 +118,13 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			$cache_timeout = $update_params->get('cachetimeout', 6, 'int');
 			$cache_timeout = 3600 * $cache_timeout;
 		}
+
+		// Get Joomla! updates.
 		try
 		{
-			// Try to connect to Joomla! Update Server. Trows exception if connection not available.
+			// Try to connect to Joomla! Update Server. Throws an exception if connection not available.
 			JHttpFactory::getHttp()->get('https://update.joomla.org/');
+
 			// Get Joomla! updates.
 			JUpdater::getInstance()->findUpdates(700, $cache_timeout);
 		}

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -123,7 +123,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			if (!JUpdater::getInstance()->findUpdates(700, $cache_timeout))
 			{
 				// If the joomla update return nothing, let's see if this is caused by unable to connect to joomla update server.
-				JHttpFactory::getHttp()->get('https://updsdfate.joomla.org/');
+				JHttpFactory::getHttp()->get('https://update.joomla.org/');
 			}
 		}
 		catch (RuntimeException $e)

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -37,12 +37,12 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			// "Minor & Patch Release for Current version AND Next Major Release".
 			case 'sts':
 			case 'next':
-				$updateURL = 'http://update.joomla.org/core/sts/list_sts.xml';
+				$updateURL = 'https://update.joomla.org/core/sts/list_sts.xml';
 				break;
 
 			// "Testing"
 			case 'testing':
-				$updateURL = 'http://update.joomla.org/core/test/list_test.xml';
+				$updateURL = 'https://update.joomla.org/core/test/list_test.xml';
 				break;
 
 			// "Custom"
@@ -66,7 +66,18 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			 * case 'nochange':
 			 */
 			default:
-				$updateURL = 'http://update.joomla.org/core/list.xml';
+				$updateURL = 'https://update.joomla.org/core/list.xml';
+		}
+
+		// Try to connect to Joomla! Update CDN Server with HTTPS.
+		// Throws an exception and changes to downloads.joomla.org if connection to update CDN server is not available.
+		if (strpos($updateURL, 'https://update.joomla.org') !== false)
+		{
+			if (!$this->canConnectToServer('https://update.joomla.org/'))
+			{
+				JFactory::getApplication()->enqueueMessage(JText::_('JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION'), 'warning');
+				return;
+			}
 		}
 
 		$db = $this->getDbo();
@@ -120,18 +131,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		}
 
 		// Get Joomla! updates.
-		try
-		{
-			// Try to connect to Joomla! Update Server. Throws an exception if connection not available.
-			JHttpFactory::getHttp()->get('https://update.joomla.org/');
-
-			// Get Joomla! updates.
-			JUpdater::getInstance()->findUpdates(700, $cache_timeout);
-		}
-		catch (RuntimeException $e)
-		{
-			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION'), 'warning');
-		}
+		JUpdater::getInstance()->findUpdates(700, $cache_timeout);
 	}
 
 	/**
@@ -818,5 +818,28 @@ ENDDATA;
 
 		// Unset the update filename from the session.
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
+	}
+
+	/**
+	 * Check if server can connect to a remove server server.
+	 *
+	 * @return  boolean   flase if server cannot connect to Joomla update server, true otherwise.
+	 *
+	 * @since   3.5.0
+	 */
+	public function canConnectToServer($uri = 'https://update.joomla.org/')
+	{
+		// Try to connect to Joomla! Update CDN Server with HTTPS.
+		// Throws an exception and changes to downloads.joomla.org if connection to update CDN server is not available.
+		try
+		{
+			JHttpFactory::getHttp()->get($uri);
+		}
+		catch (RuntimeException $e)
+		{
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -118,9 +118,18 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			$cache_timeout = $update_params->get('cachetimeout', 6, 'int');
 			$cache_timeout = 3600 * $cache_timeout;
 		}
-
-		$updater = JUpdater::getInstance();
-		$updater->findUpdates(700, $cache_timeout);
+		try
+		{
+			if (!JUpdater::getInstance()->findUpdates(700, $cache_timeout))
+			{
+				// If the joomla update return nothing, let's see if this is caused by unable to connect to joomla update server.
+				JHttpFactory::getHttp()->get('https://updsdfate.joomla.org/');
+			}
+		}
+		catch (RuntimeException $e)
+		{
+			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION'), 'info');
+		}
 	}
 
 	/**

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -661,6 +661,7 @@ JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL="Update: :Collection: Could not parse %s
 JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL="Update: :Extension: Could not open %s"
 JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL="Update: :Extension: Could not parse %s"
 JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
+JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION="There seems to be a problem comunicating to Joomla! update server.<br/>It could be a temporary problem with Joomla! update server or it could be related to your server configuration.<br/>If the problem persists, manually download the update package and install it using <a href='/administrator/index.php?option=com_installer' target='_blank'>Extensions Manager Installer</a>.<br /><br /><a class='btn btn-primary' href='https://github.com/joomla/joomla-cms/releases' target='_blank'>Go to Joomla! download page</a>"
 JLIB_USER_ERROR_AUTHENTICATION_FAILED_LOAD_PLUGIN="JAuthentication: :authenticate: Failed to load plugin: %s"
 JLIB_USER_ERROR_AUTHENTICATION_LIBRARIES="JAuthentication: :__construct: Could not load authentication libraries."
 JLIB_USER_ERROR_BIND_ARRAY="Unable to bind array to user object."

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -661,7 +661,7 @@ JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL="Update: :Collection: Could not parse %s
 JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL="Update: :Extension: Could not open %s"
 JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL="Update: :Extension: Could not parse %s"
 JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
-JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION="There seems to be a problem comunicating to Joomla! update server.<br/>It could be a temporary problem with Joomla! update server or it could be related to your server configuration.<br/>If the problem persists, manually download the update package and install it using <a href='/administrator/index.php?option=com_installer' target='_blank'>Extensions Manager Installer</a>.<br /><br /><a class='btn btn-primary' href='https://github.com/joomla/joomla-cms/releases' target='_blank'>Go to Joomla! download page</a>"
+JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION="There seems to be a problem comunicating to Joomla! update server.<br/>It could be a temporary problem with Joomla! update server or it could be related to your server configuration.<br />If the problem persists, manually download <a href='https://github.com/joomla/joomla-cms/releases' target='_blank'>Joomla! update package</a> for your version and install it using <a href='/administrator/index.php?option=com_installer'>Extensions Manager Installer</a>."
 JLIB_USER_ERROR_AUTHENTICATION_FAILED_LOAD_PLUGIN="JAuthentication: :authenticate: Failed to load plugin: %s"
 JLIB_USER_ERROR_AUTHENTICATION_LIBRARIES="JAuthentication: :__construct: Could not load authentication libraries."
 JLIB_USER_ERROR_BIND_ARRAY="Unable to bind array to user object."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -661,6 +661,7 @@ JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL="Update: :Collection: Could not parse %s
 JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL="Update: :Extension: Could not open %s"
 JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL="Update: :Extension: Could not parse %s"
 JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
+JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION="There seems to be a problem comunicating to Joomla! update server.<br/>It could be a temporary problem with Joomla! update server or it could be related to your server configuration.<br/>If the problem persists, manually download the update package and install it using <a href='/administrator/index.php?option=com_installer' target='_blank'>Extensions Manager Installer</a>.<br /><br /><a class='btn btn-primary' href='https://github.com/joomla/joomla-cms/releases' target='_blank'>Go to Joomla! download page</a>"
 JLIB_USER_ERROR_AUTHENTICATION_FAILED_LOAD_PLUGIN="JAuthentication: :authenticate: Failed to load plugin: %s"
 JLIB_USER_ERROR_AUTHENTICATION_LIBRARIES="JAuthentication: :__construct: Could not load authentication libraries."
 JLIB_USER_ERROR_BIND_ARRAY="Unable to bind array to user object."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -661,7 +661,7 @@ JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL="Update: :Collection: Could not parse %s
 JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL="Update: :Extension: Could not open %s"
 JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL="Update: :Extension: Could not parse %s"
 JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE="Update: Could not open update site #%d &quot;%s&quot;, URL: %s"
-JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION="There seems to be a problem comunicating to Joomla! update server.<br/>It could be a temporary problem with Joomla! update server or it could be related to your server configuration.<br/>If the problem persists, manually download the update package and install it using <a href='/administrator/index.php?option=com_installer' target='_blank'>Extensions Manager Installer</a>.<br /><br /><a class='btn btn-primary' href='https://github.com/joomla/joomla-cms/releases' target='_blank'>Go to Joomla! download page</a>"
+JLIB_UPDATER_ERROR_MANUAL_UPDATE_INFORMATION="There seems to be a problem comunicating to Joomla! update server.<br/>It could be a temporary problem with Joomla! update server or it could be related to your server configuration.<br/>If the problem persists, manually download <a href='https://github.com/joomla/joomla-cms/releases' target='_blank'>Joomla! update package</a> for your version and install it using <a href='/administrator/index.php?option=com_installer'>Extensions Manager Installer</a>."
 JLIB_USER_ERROR_AUTHENTICATION_FAILED_LOAD_PLUGIN="JAuthentication: :authenticate: Failed to load plugin: %s"
 JLIB_USER_ERROR_AUTHENTICATION_LIBRARIES="JAuthentication: :__construct: Could not load authentication libraries."
 JLIB_USER_ERROR_BIND_ARRAY="Unable to bind array to user object."


### PR DESCRIPTION
#### Summary of Changes

This PR adds a more descriptive message when the connections to Joomla update server fails for some reason.

Example:
![image](https://cloud.githubusercontent.com/assets/9630530/13504465/83bbb09e-e16c-11e5-88fc-c2ff25b6b699.png)
#### Testing Instructions
1. Apply this patch in joomla latest staging
2. Force an update server error.
   
   For instance, change the update server domain from `https://update.joomla.org/` to `https://anything.joomla.org/`  in https://github.com/joomla/joomla-cms/compare/staging...andrepereiradasilva:update-problem-info#diff-35b54662480daa18b046886a634f00d6R126
#### Observations

I'm no expert in the Joomla! upgrade process, this is more like a _Proof of Concept_ that Joomla can help users more when problems happens (and they sometimes happens...) in the upgrade process. 
Even if agreed, still needs revision from experts in update process so it will not break anything.

The text itself serves as an example, can be improved.
