### PR TITLE
[HTTPS] Finalize update server to https process

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-25.sql
@@ -1,0 +1,4 @@
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/core/list.xml' WHERE `name` = 'Joomla! Core' AND `type` = 'collection';
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/jed/list.xml' WHERE `name` = 'Joomla! Extension Directory' AND `type` = 'collection';
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/language/translationlist_3.xml' WHERE `name` = 'Accredited Joomla! Translations' AND `type` = 'collection';
+UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml' WHERE `name` = 'Joomla! Update Component Update Site' AND `type` = 'extension';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.1-2016-03-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.1-2016-03-25.sql
@@ -1,0 +1,4 @@
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/core/list.xml' WHERE "name" = 'Joomla! Core' AND "type" = 'collection';
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/jed/list.xml' WHERE "name" = 'Joomla! Extension Directory' AND "type" = 'collection';
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/language/translationlist_3.xml' WHERE "name" = 'Accredited Joomla! Translations' AND "type" = 'collection';
+UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml' WHERE "name" = 'Joomla! Update Component Update Site' AND "type" = 'extension';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.1-2016-03-25.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.1-2016-03-25.sql
@@ -1,0 +1,4 @@
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/core/list.xml' WHERE [name] = 'Joomla! Core' AND [type] = 'collection';
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/jed/list.xml' WHERE [name] = 'Joomla! Extension Directory' AND [type] = 'collection';
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/language/translationlist_3.xml' WHERE [name] = 'Accredited Joomla! Translations' AND [type] = 'collection';
+UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml' WHERE [name] = 'Joomla! Update Component Update Site' AND [type] = 'extension';

--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -26,7 +26,7 @@
 		</languages>
 	</administration>
 	<updateservers>
-		<server type="extension" name="Joomla! Update Component Update Site">http://update.joomla.org/core/extensions/com_joomlaupdate.xml</server>
+		<server type="extension" name="Joomla! Update Component Update Site">https://update.joomla.org/core/extensions/com_joomlaupdate.xml</server>
 	</updateservers>
 </extension>
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -37,12 +37,12 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			// "Minor & Patch Release for Current version AND Next Major Release".
 			case 'sts':
 			case 'next':
-				$updateURL = 'http://update.joomla.org/core/sts/list_sts.xml';
+				$updateURL = 'https://update.joomla.org/core/sts/list_sts.xml';
 				break;
 
 			// "Testing"
 			case 'testing':
-				$updateURL = 'http://update.joomla.org/core/test/list_test.xml';
+				$updateURL = 'https://update.joomla.org/core/test/list_test.xml';
 				break;
 
 			// "Custom"
@@ -66,7 +66,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 			 * case 'nochange':
 			 */
 			default:
-				$updateURL = 'http://update.joomla.org/core/list.xml';
+				$updateURL = 'https://update.joomla.org/core/list.xml';
 		}
 
 		$db = $this->getDbo();

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -48,7 +48,7 @@
 	</fileset>
 
 	<updateservers>
-		<server type="collection">http://update.joomla.org/core/list.xml</server>
-		<server type="collection">http://update.joomla.org/jed/list.xml</server>
+		<server type="collection">https://update.joomla.org/core/list.xml</server>
+		<server type="collection">https://update.joomla.org/jed/list.xml</server>
 	</updateservers>
 </extension>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -19,7 +19,7 @@
 	</files>
 	<updateservers>
 		<server type="collection" priority="1" name="Accredited Joomla! Translations">
-			http://update.joomla.org/language/translationlist_3.xml
+			https://update.joomla.org/language/translationlist_3.xml
 		</server>
 	</updateservers>
 </extension>

--- a/components/com_users/controllers/profile_base_json.php
+++ b/components/com_users/controllers/profile_base_json.php
@@ -31,7 +31,7 @@ class UsersControllerProfile_Base_Json extends JControllerLegacy
 		// Set FTP credentials, if given
 		JClientHelper::setCredentialsFromRequest('ftp');
 
-		if (($data = file_get_contents('http://update.joomla.org/helpsites/helpsites.xml')) === false)
+		if (($data = file_get_contents('https://update.joomla.org/helpsites/helpsites.xml')) === false)
 		{
 			throw new Exception(JText::_('COM_CONFIG_ERROR_HELPREFRESH_FETCH'), 500);
 		}

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1784,10 +1784,10 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
 --
 
 INSERT INTO `#__update_sites` (`update_site_id`, `name`, `type`, `location`, `enabled`, `last_check_timestamp`) VALUES
-(1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
-(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0),
-(4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
+(1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
+(2, 'Joomla! Extension Directory', 'collection', 'https://update.joomla.org/jed/list.xml', 1, 0),
+(3, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_3.xml', 1, 0),
+(4, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1708,10 +1708,10 @@ COMMENT ON TABLE "#__update_sites" IS 'Update Sites';
 -- Dumping data for table #__update_sites
 --
 INSERT INTO "#__update_sites" ("update_site_id", "name", "type", "location", "enabled", "last_check_timestamp") VALUES
-(1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
-(3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0),
-(4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
+(1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
+(2, 'Joomla! Extension Directory', 'collection', 'https://update.joomla.org/jed/list.xml', 1, 0),
+(3, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_3.xml', 1, 0),
+(4, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 SELECT setval('#__update_sites_update_site_id_seq', 5, false);
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2711,13 +2711,13 @@ CREATE TABLE [#__update_sites](
 SET IDENTITY_INSERT [#__update_sites] ON;
 
 INSERT INTO [#__update_sites] ([update_site_id], [name], [type], [location], [enabled], [last_check_timestamp])
-SELECT 1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0
+SELECT 1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0
 UNION ALL
-SELECT 2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0
+SELECT 2, 'Joomla! Extension Directory', 'collection', 'https://update.joomla.org/jed/list.xml', 1, 0
 UNION ALL
-SELECT 3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0
+SELECT 3, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_3.xml', 1, 0
 UNION ALL
-SELECT 4, 'Joomla! Update Component Update Site', 'extension', 'http://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0;
+SELECT 4, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0;
 
 SET IDENTITY_INSERT [#__update_sites] OFF;
 


### PR DESCRIPTION
#### Summary of Changes

This PR is a revival of https://github.com/joomla/joomla-cms/pull/8196 that was closed then because the update server did not fully supported HTTPS by then.

Now that the update server is working in HTTPS i think we can now safely update all update.joomla.org `http://` references to `https://`.
#### Testing Instructions
##### Update
1. Apply this patch to latest staging
2. Run the queries from `/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-25.sql` (replace `#__` for your table prefix)
3. Check if the update server URI are in https in `#__update_sites` table.
4. Test if fetching for a joomla update does not give any error.
##### New installation
1. Download Joomla 3.5.0 (https://github.com/joomla/joomla-cms/releases/download/3.5.0/Joomla_3.5.0-Stable-Full_Package.zip)
2. Unzip and then manually apply the changes in this PR
3. Install joomla
4. Check if the update server URI are in https in `#__update_sites` table.
5. Test if fetching for a joomla update does not give any error.
