### PR TITLE
[system messages] Add new options for custom title and/or hide title

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/system/message.php
+++ b/administrator/templates/isis/html/layouts/joomla/system/message.php
@@ -9,17 +9,26 @@
 
 defined('_JEXEC') or die;
 
-$msgList = $displayData['msgList'];
+$msgList = $displayData['msgQueue'];
 
 $alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-info', 'message' => 'alert-success');
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && $msgList) : ?>
 		<button type="button" class="close" data-dismiss="alert">&times;</button>
-		<?php foreach ($msgList as $type => $msgs) : ?>
+		<?php foreach ($msgList as $groupIdentifier => $msgs) : ?>
+			<?php $options = unserialize($groupIdentifier); ?>
+			<?php $type    = $options['type']; ?>
 			<div class="alert <?php echo isset($alert[$type]) ? $alert[$type] : 'alert-' . $type; ?>">
-				<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
 				<?php if ($msgs) : ?>
+					<?php if ($options['showTitle']) : ?>
+						<?php if ($options['customTitle'] !== '') : ?>
+							<?php $title = $options['customTitle']; ?>
+						<?php else : ?>
+							<?php $title = $type; ?>
+						<?php endif; ?>
+						<h4 class="alert-heading"><?php echo JText::_($title); ?></h4>
+					<?php endif; ?>
 					<?php foreach ($msgs as $msg) : ?>
 						<div class="alert-message"><?php echo $msg; ?></div>
 					<?php endforeach; ?>

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -10,7 +10,6 @@
 defined('JPATH_BASE') or die;
 
 $msgList = $displayData['msgQueue'];
-print_r($msgList);
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && !empty($msgList)) : ?>

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -9,22 +9,31 @@
 
 defined('JPATH_BASE') or die;
 
-$msgList = $displayData['msgList'];
-
+$msgList = $displayData['msgQueue'];
+print_r($msgList);
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && !empty($msgList)) : ?>
 		<div id="system-message">
-			<?php foreach ($msgList as $type => $msgs) : ?>
+			<?php foreach ($msgList as $groupIdentifier => $msgs) : ?>
+				<?php $options = unserialize($groupIdentifier); ?>
+				<?php $type    = $options['type']; ?>
 				<div class="alert alert-<?php echo $type; ?>">
 					<?php // This requires JS so we should add it trough JS. Progressive enhancement and stuff. ?>
 					<a class="close" data-dismiss="alert">×</a>
 
 					<?php if (!empty($msgs)) : ?>
-						<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
+						<?php if ($options['showTitle']) : ?>
+							<?php if ($options['customTitle'] !== '') : ?>
+								<?php $title = $options['customTitle']; ?>
+							<?php else : ?>
+								<?php $title = $type; ?>
+							<?php endif; ?>
+							<h4 class="alert-heading"><?php echo JText::_($title); ?></h4>
+						<?php endif; ?>
 						<div>
 							<?php foreach ($msgs as $msg) : ?>
-								<div class="alert-message"><?php echo $msg; ?></div>
+								<div class="alert-message"><?php echo $msg['message']; ?></div>
 							<?php endforeach; ?>
 						</div>
 					<?php endif; ?>

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -32,7 +32,7 @@ $msgList = $displayData['msgQueue'];
 						<?php endif; ?>
 						<div>
 							<?php foreach ($msgs as $msg) : ?>
-								<div class="alert-message"><?php echo $msg['message']; ?></div>
+								<div class="alert-message"><?php echo $msg; ?></div>
 							<?php endforeach; ?>
 						</div>
 					<?php endif; ?>

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -217,14 +217,17 @@ class JApplicationCms extends JApplicationWeb
 	/**
 	 * Enqueue a system message.
 	 *
-	 * @param   string  $msg   The message to enqueue.
-	 * @param   string  $type  The message type. Default is message.
+	 * @param   string  $msg      The message to enqueue.
+	 * @param   string  $type     The message type. Default is message.
+	 * @param   mixed   $options  Array with message options:
+	 *                            - showTitle (true/false): Show message title.
+	 *                            - customTitle (string): Custom message title.
 	 *
 	 * @return  void
 	 *
 	 * @since   3.2
 	 */
-	public function enqueueMessage($msg, $type = 'message')
+	public function enqueueMessage($msg, $type = 'message', $options = array())
 	{
 		// Don't add empty messages.
 		if (!strlen($msg))
@@ -235,7 +238,12 @@ class JApplicationCms extends JApplicationWeb
 		// For empty queue, if messages exists in the session, enqueue them first.
 		$messages = $this->getMessageQueue();
 
-		$message = array('message' => $msg, 'type' => strtolower($type));
+		// Default options values.
+		$options['showTitle']   = (isset($options['showTitle'])) ? $options['showTitle'] : true;
+		$options['customTitle'] = (isset($options['customTitle'])) ? $options['customTitle'] : '';
+
+		// Enqueue the message.
+		$message = array('message' => $msg, 'type' => strtolower($type), 'options' => $options);
 
 		if (!in_array($message, $this->_messageQueue))
 		{

--- a/libraries/joomla/document/renderer/html/message.php
+++ b/libraries/joomla/document/renderer/html/message.php
@@ -59,7 +59,7 @@ class JDocumentRendererHtmlMessage extends JDocumentRenderer
 	/**
 	 * Get and prepare system message data for output
 	 *
-	 * @param   integer  version   Type of returned array. 1 for B/C mode.
+	 * @param   integer  $version  Type of returned array. 1 for B/C mode.
 	 * 
 	 * @return  array  An array contains system message
 	 *

--- a/libraries/joomla/document/renderer/html/message.php
+++ b/libraries/joomla/document/renderer/html/message.php
@@ -59,6 +59,8 @@ class JDocumentRendererHtmlMessage extends JDocumentRenderer
 	/**
 	 * Get and prepare system message data for output
 	 *
+	 * @param   integer  version   Type of returned array. 1 for B/C mode.
+	 * 
 	 * @return  array  An array contains system message
 	 *
 	 * @since   3.5

--- a/libraries/joomla/document/renderer/html/message.php
+++ b/libraries/joomla/document/renderer/html/message.php
@@ -31,10 +31,11 @@ class JDocumentRendererHtmlMessage extends JDocumentRenderer
 	{
 		$msgList     = $this->getData();
 		$displayData = array(
-			'msgList' => $msgList,
-			'name'    => $name,
-			'params'  => $params,
-			'content' => $content
+			'msgList'  => $msgList,
+			'msgQueue' => $this->getData(2),
+			'name'     => $name,
+			'params'   => $params,
+			'content'  => $content
 		);
 
 		$app        = JFactory::getApplication();
@@ -62,7 +63,7 @@ class JDocumentRendererHtmlMessage extends JDocumentRenderer
 	 *
 	 * @since   3.5
 	 */
-	private function getData()
+	private function getData($version = 1)
 	{
 		// Initialise variables.
 		$lists = array();
@@ -77,7 +78,16 @@ class JDocumentRendererHtmlMessage extends JDocumentRenderer
 			{
 				if (isset($msg['type']) && isset($msg['message']))
 				{
-					$lists[$msg['type']][] = $msg['message'];
+					if ($version === 1)
+					{
+						$groupIdentifier = $msg['type'];
+					}
+					else
+					{
+						$groupIdentifier = serialize(array_replace($msg['options'], array('type' => $msg['type'])));
+					}
+
+					$lists[$groupIdentifier][] = $msg['message'];
 				}
 			}
 		}

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -412,15 +412,18 @@ class JApplication extends JApplicationBase
 	/**
 	 * Enqueue a system message.
 	 *
-	 * @param   string  $msg   The message to enqueue.
-	 * @param   string  $type  The message type. Default is message.
+	 * @param   string  $msg      The message to enqueue.
+	 * @param   string  $type     The message type. Default is message.
+	 * @param   mixed   $options  Array with message options:
+	 *                            - showTitle (true/false): Show message title.
+	 *                            - customTitle (string): Custom message title.
 	 *
 	 * @return  void
 	 *
 	 * @since   11.1
 	 * @deprecated  4.0
 	 */
-	public function enqueueMessage($msg, $type = 'message')
+	public function enqueueMessage($msg, $type = 'message', $options = array())
 	{
 		// For empty queue, if messages exists in the session, enqueue them first.
 		if (!count($this->_messageQueue))
@@ -435,8 +438,12 @@ class JApplication extends JApplicationBase
 			}
 		}
 
+		// Default options values.
+		$options['showTitle']   = (isset($options['showTitle'])) ? $options['showTitle'] : true;
+		$options['customTitle'] = (isset($options['customTitle'])) ? $options['customTitle'] : '';
+
 		// Enqueue the message.
-		$this->_messageQueue[] = array('message' => $msg, 'type' => strtolower($type));
+		$this->_messageQueue[] = array('message' => $msg, 'type' => strtolower($type), 'options' => $options);
 	}
 
 	/**

--- a/templates/beez3/html/layouts/joomla/system/message.php
+++ b/templates/beez3/html/layouts/joomla/system/message.php
@@ -9,14 +9,25 @@
 
 defined('_JEXEC') or die;
 
-$msgList = $displayData['msgList'];
-
+$msgList = $displayData['msgQueue'];
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && $msgList) : ?>
 		<dl id="system-message">
-			<?php foreach ($msgList as $type => $msgs) : ?>
+			<?php foreach ($msgList as $groupIdentifier => $msgs) : ?>
+				<?php $options = unserialize($groupIdentifier); ?>
+				<?php $type    = $options['type']; ?>
 				<?php if ($msgs) : ?>
+					<?php if ($options['showTitle']) : ?>
+						<?php if ($options['customTitle'] !== '') : ?>
+							<?php $title = $options['customTitle']; ?>
+						<?php else : ?>
+							<?php $title = $type; ?>
+						<?php endif; ?>
+						<dt class="<?php echo strtolower($type); ?>"><?php echo JText::_($title); ?></dt>
+					<?php else : ?>
+						<dt class="<?php echo strtolower($type); ?>">&nbsp;</dt>
+					<?php endif; ?>
 					<dt class="<?php echo strtolower($type); ?>"><?php echo JText::_($type); ?></dt>
 					<dd class="<?php echo strtolower($type); ?> message">
 						<ul>

--- a/templates/protostar/html/layouts/joomla/system/message.php
+++ b/templates/protostar/html/layouts/joomla/system/message.php
@@ -9,20 +9,29 @@
 
 defined('_JEXEC') or die;
 
-$msgList = $displayData['msgList'];
+$msgList = $displayData['msgQueue'];
 
 $alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-info', 'message' => 'alert-success');
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && !empty($msgList)) : ?>
 		<div id="system-message">
-			<?php foreach ($msgList as $type => $msgs) : ?>
+			<?php foreach ($msgList as $groupIdentifier => $msgs) : ?>
+				<?php $options = unserialize($groupIdentifier); ?>
+				<?php $type    = $options['type']; ?>
 				<div class="alert <?php echo isset($alert[$type]) ? $alert[$type] : 'alert-' . $type; ?>">
 					<?php // This requires JS so we should add it trough JS. Progressive enhancement and stuff. ?>
 					<a class="close" data-dismiss="alert">×</a>
 
 					<?php if (!empty($msgs)) : ?>
-						<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
+						<?php if ($options['showTitle']) : ?>
+							<?php if ($options['customTitle'] !== '') : ?>
+								<?php $title = $options['customTitle']; ?>
+							<?php else : ?>
+								<?php $title = $type; ?>
+							<?php endif; ?>
+							<h4 class="alert-heading"><?php echo JText::_($title); ?></h4>
+						<?php endif; ?>
 						<div>
 							<?php foreach ($msgs as $msg) : ?>
 								<div class="alert-message"><?php echo $msg; ?></div>

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -436,6 +436,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array(
 					'message' => 'Test Message',
 					'type' => 'message'
+					'options' => array(),
 				)
 			),
 			$this->class->getMessageQueue()

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -435,7 +435,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 			array(
 				array(
 					'message' => 'Test Message',
-					'type' => 'message'
+					'type' => 'message',
 					'options' => array(),
 				)
 			),

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -436,7 +436,10 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array(
 					'message' => 'Test Message',
 					'type' => 'message',
-					'options' => array(),
+					'options' => array(
+						'showTitle' => true,
+						'customTitle' => '',
+					)
 				)
 			),
 			$this->class->getMessageQueue()


### PR DESCRIPTION
#### Summary of Changes

The system messages are somewhat limited, since we can't change their title or even with their title.

To solve this, this PR adds new options for system messages.
- Allows to hide the message title.
- Allows to add a custom title.

Also, make it easier to add other message group options in the future (if needed).

This PR also applies the changes need in all layouts (system, isis, protostar and beez3).
#### Testing Instructions
- Test if messages are working fine
- Then add the following code to the beggining of the `index.php` file of the Joomla templates (protostar, beez3, isis and hathor):

``` php
JFactory::getApplication()->enqueueMessage('Test 1: Message without group (fallbacks to <code>message</code> group).');
JFactory::getApplication()->enqueueMessage('Test 2: Message in <code>error</code> group.', 'error');
JFactory::getApplication()->enqueueMessage('Test 3: Message in <code>notice</code> group.', 'notice');
JFactory::getApplication()->enqueueMessage('Test 4: Message in <code>warning</code> group.', 'warning');
JFactory::getApplication()->enqueueMessage('Test 5: Message in <code>message</code> group (will be in the same queue as test 1).', 'message');
JFactory::getApplication()->enqueueMessage('Test 6: Message in <code>message without title</code> group.', 'message', array('showTitle' => false));
JFactory::getApplication()->enqueueMessage('Test 7: Message in <code>notice with custom title</code> group.', 'notice', array('customTitle' => 'My custom title'));
JFactory::getApplication()->enqueueMessage('Test 8: Message in <code>notice with custom title</code> group (message 2).', 'notice', array('customTitle' => 'My custom title'));
```
- Check if the result is something like this (please not that in beez3 there is no message title):
  ![image](https://cloud.githubusercontent.com/assets/9630530/14258865/4dda811e-fa9c-11e5-9281-30e21e8f2681.png)
#### Observations

An effort was made to preserve B/C. But you can also try this patch in a custom template current message layout override.

XXXXXXXX i had to change `JDocumentRendererHtmlMessage` and `enqueueMessage` (normal and legacy) to make this work with the new options, please check if everything is fine with this changes.

Any suggestions and/or improvements are welcomed.
