### PR TITLE
en-GB language pack package correction (fix inconsistency)

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -357,7 +357,7 @@ class JoomlaInstallerScript
 			array('file', 'joomla', '', 0),
 
 			// Packages
-			// None in core at this time
+			array('package', 'en-GB', '', 0),
 		);
 
 		// Attempt to refresh manifest caches

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -357,7 +357,7 @@ class JoomlaInstallerScript
 			array('file', 'joomla', '', 0),
 
 			// Packages
-			array('package', 'en-GB', '', 0),
+			array('package', 'pkg_en-GB', '', 0),
 		);
 
 		// Attempt to refresh manifest caches

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
@@ -2,5 +2,5 @@
 INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`)
  VALUES (602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
--- change update site extension id.
+-- Change update site extension id to the new extension.
 UPDATE `#__update_sites_extensions` SET `extension_id` = 602 WHERE `update_site_id` = 3 AND `extension_id` = 600;

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
@@ -1,0 +1,6 @@
+-- Insert the missing en-GB package extension.
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`)
+ VALUES (602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+
+-- change update site extension id.
+UPDATE `#__update_sites_extensions` SET `extension_id` = 602 WHERE `update_site_id` = 3 AND `extension_id` = 600;

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
@@ -1,6 +1,6 @@
 -- Insert the missing en-GB package extension.
 INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`)
- VALUES (602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+ VALUES (602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- Change update site extension id to the new extension.
 UPDATE `#__update_sites_extensions` SET `extension_id` = 602 WHERE `update_site_id` = 3 AND `extension_id` = 600;

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.2-2016-04-08.sql
@@ -1,6 +1,6 @@
 -- Insert the missing en-GB package extension.
 INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`)
- VALUES (602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+ VALUES (650, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- Change update site extension id to the new extension.
-UPDATE `#__update_sites_extensions` SET `extension_id` = 602 WHERE `update_site_id` = 3 AND `extension_id` = 600;
+UPDATE `#__update_sites_extensions` SET `extension_id` = 650 WHERE `update_site_id` = 3 AND `extension_id` = 600;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.2-2016-04-08.sql
@@ -1,4 +1,4 @@
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 UPDATE "#__update_sites_extensions" SET "extension_id" = 602 WHERE "update_site_id" = 3 AND "extension_id" = 600;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.2-2016-04-08.sql
@@ -1,0 +1,4 @@
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+
+UPDATE "#__update_sites_extensions" SET "extension_id" = 602 WHERE "update_site_id" = 3 AND "extension_id" = 600;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.2-2016-04-08.sql
@@ -1,4 +1,4 @@
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(650, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
-UPDATE "#__update_sites_extensions" SET "extension_id" = 602 WHERE "update_site_id" = 3 AND "extension_id" = 600;
+UPDATE "#__update_sites_extensions" SET "extension_id" = 650 WHERE "update_site_id" = 3 AND "extension_id" = 600;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.2-2016-04-08.sql
@@ -1,8 +1,8 @@
 SET IDENTITY_INSERT [#__extensions]  ON;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 650, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT [#__extensions]  OFF;
 
-UPDATE [#__update_sites_extensions] SET [extension_id] = 602 WHERE [update_site_id] = 8 AND [extension_id] = 600;
+UPDATE [#__update_sites_extensions] SET [extension_id] = 650 WHERE [update_site_id] = 8 AND [extension_id] = 600;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.2-2016-04-08.sql
@@ -1,0 +1,8 @@
+SET IDENTITY_INSERT [#__extensions]  ON;
+
+INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+SELECT 602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+
+SET IDENTITY_INSERT [#__extensions]  OFF;
+
+UPDATE [#__update_sites_extensions] SET [extension_id] = 602 WHERE [update_site_id] = 8 AND [extension_id] = 600;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.2-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.2-2016-04-08.sql
@@ -1,7 +1,7 @@
 SET IDENTITY_INSERT [#__extensions]  ON;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT [#__extensions]  OFF;
 

--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -51,13 +51,11 @@ class InstallerModelLanguages extends JModelList
 		// Get the extension_id of the en-GB package.
 		$db        = $this->getDbo();
 		$extQuery  = $db->getQuery(true);
-		$extType   = 'language';
-		$extElem   = 'en-GB';
 
 		$extQuery->select($db->quoteName('extension_id'))
 			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('type') . ' = ' . $db->quote($extType))
-			->where($db->quoteName('element') . ' = ' . $db->quote($extElem))
+			->where($db->quoteName('type') . ' = ' . $db->quote('package'))
+			->where($db->quoteName('element') . ' = ' . $db->quote('en-GB'))
 			->where($db->quoteName('client_id') . ' = 0');
 
 		$db->setQuery($extQuery);

--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -55,7 +55,7 @@ class InstallerModelLanguages extends JModelList
 		$extQuery->select($db->quoteName('extension_id'))
 			->from($db->quoteName('#__extensions'))
 			->where($db->quoteName('type') . ' = ' . $db->quote('package'))
-			->where($db->quoteName('element') . ' = ' . $db->quote('en-GB'))
+			->where($db->quoteName('element') . ' = ' . $db->quote('pkg_en-GB'))
 			->where($db->quoteName('client_id') . ' = 0');
 
 		$db->setQuery($extQuery);

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.5.2</version>
+	<version>3.5.2.0</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.5.0.1</version>
+	<version>3.5.2</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.5.2.0</version>
+	<version>3.5.2</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.5.2</version>
+	<version>3.5.2.1</version>
 	<creationDate>2013-03-07</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -84,7 +84,7 @@ class InstallationModelLanguages extends JModelBase
 
 		$extQuery->select($db->qn('extension_id'))
 			->from($db->qn('#__extensions'))
-			->where($db->qn('type') . ' = ' . $db->q('language'))
+			->where($db->qn('type') . ' = ' . $db->q('package'))
 			->where($db->qn('element') . ' = ' . $db->q('en-GB'))
 			->where($db->qn('client_id') . ' = 0');
 

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -85,7 +85,7 @@ class InstallationModelLanguages extends JModelBase
 		$extQuery->select($db->qn('extension_id'))
 			->from($db->qn('#__extensions'))
 			->where($db->qn('type') . ' = ' . $db->q('package'))
-			->where($db->qn('element') . ' = ' . $db->q('en-GB'))
+			->where($db->qn('element') . ' = ' . $db->q('pkg_en-GB'))
 			->where($db->qn('client_id') . ' = 0');
 
 		$db->setQuery($extQuery);

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -617,6 +617,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (507, 'isis', 'template', 'isis', '', 1, 1, 1, 0, '', '{"templateColor":"","logoFile":""}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- --------------------------------------------------------
@@ -1808,7 +1809,7 @@ CREATE TABLE IF NOT EXISTS `#__update_sites_extensions` (
 INSERT INTO `#__update_sites_extensions` (`update_site_id`, `extension_id`) VALUES
 (1, 700),
 (2, 700),
-(3, 600),
+(3, 602),
 (4, 28);
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -617,7 +617,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (507, 'isis', 'template', 'isis', '', 1, 1, 1, 0, '', '{"templateColor":"","logoFile":""}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -617,7 +617,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (507, 'isis', 'template', 'isis', '', 1, 1, 1, 0, '', '{"templateColor":"","logoFile":""}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(650, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- --------------------------------------------------------
@@ -1809,7 +1809,7 @@ CREATE TABLE IF NOT EXISTS `#__update_sites_extensions` (
 INSERT INTO `#__update_sites_extensions` (`update_site_id`, `extension_id`) VALUES
 (1, 700),
 (2, 700),
-(3, 602),
+(3, 650),
 (4, 28);
 
 -- --------------------------------------------------------

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1736,7 +1736,7 @@ COMMENT ON TABLE "#__update_sites_extensions" IS 'Links extensions to update sit
 INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALUES
 (1, 700),
 (2, 700),
-(3, 602),
+(3, 650),
 (4, 28);
 
 --

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -623,7 +623,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 (600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Files Extensions
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -622,7 +622,8 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 -- Languages
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 (600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
+(602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Files Extensions
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
@@ -1732,7 +1733,7 @@ COMMENT ON TABLE "#__update_sites_extensions" IS 'Links extensions to update sit
 INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALUES
 (1, 700),
 (2, 700),
-(3, 600),
+(3, 602),
 (4, 28);
 
 --

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -622,8 +622,11 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 -- Languages
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 (600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+
+-- Packages
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(650, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Files Extensions
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1016,9 +1016,10 @@ SELECT 507, 'isis', 'template', 'isis', '', 1, 1, 1, 0, '', '{"templateColor":""
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
-UNION ALL
-SELECT 602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+
+INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+SELECT 650, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
@@ -2741,7 +2742,7 @@ SELECT 1, 700
 UNION ALL
 SELECT 2, 700
 UNION ALL
-SELECT 3, 602
+SELECT 3, 650
 UNION ALL
 SELECT 4, 28;
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1018,7 +1018,7 @@ SELECT 600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '',
 UNION ALL
 SELECT 601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 602, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1016,7 +1016,9 @@ SELECT 507, 'isis', 'template', 'isis', '', 1, 1, 1, 0, '', '{"templateColor":""
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
+UNION ALL
+SELECT 602, 'English (United Kingdom)', 'package', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
@@ -2739,7 +2741,7 @@ SELECT 1, 700
 UNION ALL
 SELECT 2, 700
 UNION ALL
-SELECT 3, 600
+SELECT 3, 602
 UNION ALL
 SELECT 4, 28;
 


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

As detected in PR https://github.com/joomla/joomla-cms/pull/9744, there is an inconsistency in the en-GB language extensions.

The default language (en-GB) should have 3 extensions like any other language pack:
1. type = language | client = Site: For the site site language
2. type = language | client = Administrator: For the administrator site language
3. type = package | client = Site: For the whole en-GB language package

But, only extensions "1." (en-GB site language) and "2." (en-GB admin language) exist in Joomla core default database.

The extension "3." (pkg_en-GB language package), although is has a [manifest file](https://github.com/joomla/joomla-cms/blob/staging/administrator/manifests/packages/pkg_en-GB.xml), doesn't have an extension in Joomla core default database.

Note that this is the only manifest file in the whole Joomla core that doesn't has an extension in the database, and for consistency it should.

This generates some inconsistencies, for instance the update server is declared in the extension "3." (en-GB language package) [manifest file](https://github.com/joomla/joomla-cms/blob/staging/administrator/manifests/packages/pkg_en-GB.xml#L20-L24), but in the database is linked to extension "1." (en-GB site language).
Extension "1." (en-GB site language) doesn't have update servers in his [manifest file](https://github.com/joomla/joomla-cms/blob/staging/language/en-GB/en-GB.xml), because is a extension of language type.

So, this PR adds the "pkg_en-GB language package" extension to new joomla installation, also adds it to the upgrade process and makes the necessary adjustments in the code.

![image](https://cloud.githubusercontent.com/assets/9630530/14370204/bfda70f6-fd23-11e5-98f6-03df2915cd06.png)

![image](https://cloud.githubusercontent.com/assets/9630530/14370212/dd1c24de-fd23-11e5-8910-12f7c60c4e55.png)
#### Testing Instructions
###### New installation
1. Install Joomla with this package https://github.com/andrepereiradasilva/joomla-cms/archive/en-gb-package-correc.zip
2. Add some languages in the end of the installation. Check if they are installed correctly.
3. Go to admin. "Extensions -> Manage -> Install languages"
4. Install some languages. Check if everything is fine
5. Go to "Extensions -> Manage -> Update Sites" and check if all "Accredited Joomla! Translations" are o the type "Package", including the en-GB one.
6. Go to "Extensions -> Manage -> Manage", filter by package and check if and languages are there. Including the en-GB (should be blocked).
###### Upgrade
1. Use 3.5.1 or latest staging
2. Install patch https://github.com/joomla/joomla-cms/pull/9612 so you can upload joomla with upload
3. Go to Joomla update component
4. Update joomla with this custom 3.5.5 package https://github.com/andrepereiradasilva/update.joomla.org/raw/master/Joomla_3.5.1_to_3.5.5-Stable-Patch_Package.zip
5. Repeat the same steps "3." to "6." of the "New installation" test.
