### PR TITLE
Normalize en-GB language xml files

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.5" client="administrator">
 	<name>English (en-GB)</name>
-	<version>3.5.2</version>
+	<version>3.5.2.0</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
+	<authorUrl>https://www.joomla.org/</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB administrator language</description>

--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.5" client="administrator">
 	<name>English (en-GB)</name>
-	<version>3.5.2.0</version>
+	<version>3.5.2</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension version="3.5" client="administrator" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>3.5.2.0</version>
+	<version>3.5.2</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.5" client="administrator" type="language" method="upgrade">
-	<name>English (United Kingdom)</name>
+	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>3.5.2</version>
-	<creationDate>2013-03-07</creationDate>
+	<version>3.5.2.0</version>
+	<creationDate>April 2006</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
+	<authorUrl>https://www.joomla.org/</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB administrator language</description>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -3,7 +3,7 @@
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>3.5.2.0</version>
-	<creationDate>April 2006</creationDate>
+	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>https://www.joomla.org/</authorUrl>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.5.2.0</version>
+	<version>3.5.2</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,16 +2,16 @@
 <extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.5.0.1</version>
-	<creationDate>2013-03-07</creationDate>
+	<version>3.5.2.0</version>
+	<creationDate>April 2006</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
+	<authorUrl>https://www.joomla.org/</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<url>https://github.com/joomla/joomla-cms</url>
 	<packager>Joomla! Project</packager>
-	<packagerurl>www.joomla.org</packagerurl>
+	<packagerurl>https://www.joomla.org/</packagerurl>
 	<description>en-GB language pack</description>
 	<files>
 		<folder type="language" client="site" id="en-GB">site_en-GB</folder>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -3,7 +3,7 @@
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
 	<version>3.5.2.0</version>
-	<creationDate>April 2006</creationDate>
+	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>https://www.joomla.org/</authorUrl>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" version="3.5" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.5.2</version>
+	<version>3.5.2.1</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/installation/language/en-GB/en-GB.xml
+++ b/installation/language/en-GB/en-GB.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile
-	version="3.5"
-	client="installation">
-	<name>English (United Kingdom)</name>
-	<version>3.5.0</version>
-	<creationDate>August 2015</creationDate>
+<metafile version="3.5" client="installation">
+	<name>English (en-GB)</name>
+	<version>3.5.2.0</version>
+	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
@@ -12,7 +10,7 @@
 		<filename>en-GB.ini</filename>
 	</files>
 	<metadata>
-		<name>English (United Kingdom)</name>
+		<name>English (en-GB)</name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 	</metadata>

--- a/installation/language/en-GB/en-GB.xml
+++ b/installation/language/en-GB/en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.5" client="installation">
 	<name>English (en-GB)</name>
-	<version>3.5.2.0</version>
+	<version>3.5.2</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.5" client="site">
 	<name>English (en-GB)</name>
-	<version>3.5.2.0</version>
+	<version>3.5.2</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.5" client="site">
 	<name>English (en-GB)</name>
-	<version>3.5.2</version>
+	<version>3.5.2.0</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
+	<authorUrl>https://www.joomla.org/</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB site language</description>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.5" client="site" type="language" method="upgrade">
-	<name>English (United Kingdom)</name>
+	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>3.5.2</version>
-	<creationDate>2013-03-07</creationDate>
+	<version>3.5.2.0</version>
+	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
-	<authorUrl>www.joomla.org</authorUrl>
+	<authorUrl>https://www.joomla.org/</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>en-GB site language</description>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension version="3.5" client="site" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>3.5.2.0</version>
+	<version>3.5.2</version>
 	<creationDate>April 2016</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>


### PR DESCRIPTION
#### Summary of Changes

This PR normalizes the fields in the **6 en-GB language xml files**.

Normalizes:
- `name`: the name of the language (or the language package). Normalize to "English (en-GB)"
- `version`: the version of the language. Normalize to 4 digits version (to normalize with the other language packages) "3.5.2.0"
- `creationDate`: The date the language version was created. Normalize to "April 2016"
- `authorUrl`: The url of the author of the language. Normalize to "https://www.joomla.org/"
- `packagerurl` (only in the package manifest): The url of the packager of the language. Normalize to "https://www.joomla.org/"
#### Testing Instructions
1. Code review.
2. Apply patch and go to "Extensions -> Language(s) -> Installed" (site and admin) and check if the data is correct.
#### Observations

As you can see in the code changes. The `install.xml` files `name` attribute was different than the manifest file. @infograf768 please confirm there is no problems with that.
