### PR TITLE
templates to html5

### DIFF
--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -18,6 +18,9 @@ $lang->load('tpl_hathor', JPATH_ADMINISTRATOR)
 $app = JFactory::getApplication();
 $doc = JFactory::getDocument();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
 

--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -86,8 +86,8 @@ else
 
 ?>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo  $this->language; ?>" lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>" >
+<!DOCTYPE html>
+<html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>" >
 <head>
 <jdoc:include type="head" />
 <!--[if lt IE 9]>

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -15,6 +15,9 @@ $lang  = JFactory::getLanguage();
 $input = $app->input;
 $user  = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -79,8 +79,8 @@ else
 }
 
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo  $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo  $this->direction; ?>">
 <head>
 <jdoc:include type="head" />
 <!-- Load additional CSS styles for Internet Explorer -->

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -82,8 +82,8 @@ else
 }
 
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo  $this->language; ?>" lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>">
 	<head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -15,6 +15,9 @@ $lang  = JFactory::getLanguage();
 $input = $app->input;
 $user  = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
 

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -79,8 +79,8 @@ else
 }
 
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
 <jdoc:include type="head" />
 

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -13,6 +13,9 @@ $app  = JFactory::getApplication();
 $lang = JFactory::getLanguage();
 $doc  = JFactory::getDocument();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
 

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -44,7 +44,7 @@ if (is_file($file))
 ?>
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 	<!--[if lt IE 9]>

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -15,6 +15,9 @@ $lang            = JFactory::getLanguage();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -60,9 +60,9 @@ $statusFixed   = $params->get('statusFixed', '1');
 $stickyToolbar = $params->get('stickyToolbar', '1');
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -22,6 +22,9 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Detecting Active Variables
 $option   = $input->get('option', '');
 $view     = $input->get('view', '');

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -17,6 +17,9 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -123,12 +123,11 @@ $doc->addScriptDeclaration(
 );
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-
 	<!-- Template color -->
 	<?php if ($navbar_color) : ?>
 		<style type="text/css">

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -13,6 +13,9 @@ $app  = JFactory::getApplication();
 $doc  = JFactory::getDocument();
 $lang = JFactory::getLanguage();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Color Params
 $background_color = $this->params->get('loginBackgroundColor') ? $this->params->get('loginBackgroundColor') : '';
 $color_is_light = ($background_color && colorIsLight($background_color));

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 </head>

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -9,24 +9,24 @@
 
 defined('_JEXEC') or die;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="templates/system/css/error.css" type="text/css" />
 </head>
 <body>
-	<table width="550" align="center" class="outline">
+	<table style="text-align: center; width: 550px;" class="outline">
 	<tr>
-		<td align="center">
+		<td style="text-align: center;">
 			<h1>
 				<?php echo $this->error->getCode() ?> - <?php echo JText::_('JERROR_AN_ERROR_HAS_OCCURRED') ?>
 			</h1>
 		</td>
 	</tr>
 	<tr>
-		<td width="39%" align="center">
+		<td width="39%" style="text-align: center;">
 			<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
 			<p><a href="index.php"><?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT') ?></a></p>
 			<p>

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -10,6 +10,10 @@
 defined('_JEXEC') or die;
 
 $doc   = JFactory::getDocument();
+
+// Output as HTML5
+$doc->setHtml5(true);
+
 $color = $this->params->get('templatecolor');
 
 $doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -45,8 +45,8 @@ if ($this->direction == 'rtl')
 	}
 }
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 <!--[if lte IE 6]>

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -24,6 +24,9 @@ $navposition = $params->get('navposition');
 $doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
+
+// Output as HTML5
+$doc->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -25,14 +25,11 @@ $doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 ?>
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-
+	<meta charset="utf-8" />
+	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/system.css" type="text/css" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/position.css" type="text/css" media="screen,projection" />

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -37,6 +37,9 @@ $bootstrap      = explode(',', $templateparams->get('bootstrap'));
 $jinput         = JFactory::getApplication()->input;
 $option         = $jinput->get('option', '', 'cmd');
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 if (in_array($option, $bootstrap))
 {
 	// Load optional rtl Bootstrap css and Bootstrap bugfixes
@@ -72,9 +75,7 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 {
 	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/user.css');
 }
-
 ?>
-
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 	<head>

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -76,16 +76,13 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 ?>
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 	<head>
 		<?php require __DIR__ . '/jsstrings.php';?>
-
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes"/>
 		<meta name="HandheldFriendly" content="true" />
 		<meta name="apple-mobile-web-app-capable" content="YES" />
-
 		<jdoc:include type="head" />
-
 		<!--[if IE 7]>
 		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" type="text/css" />
 		<![endif]-->

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -14,6 +14,9 @@ $doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -25,7 +25,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <jdoc:include type="head" />

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -15,6 +15,9 @@ $user            = JFactory::getUser();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Getting params from template
 $params = $app->getTemplate(true)->params;
 

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -53,9 +53,9 @@ else
 }
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<?php // Use of Google Font ?>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -89,7 +89,7 @@ else
 }
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -15,6 +15,9 @@ $user            = JFactory::getUser();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Getting params from template
 $params = $app->getTemplate(true)->params;
 
@@ -25,9 +28,6 @@ $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
-
-// Output as HTML5
-$doc->setHtml5(true);
 
 if($task == "edit" || $layout == "form" )
 {

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -8,6 +8,10 @@
  */
 
 defined('_JEXEC') or die;
+
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -20,6 +20,9 @@ $doc             = JFactory::getDocument();
 $app             = JFactory::getApplication();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
+
+// Output as HTML5
+$doc->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -21,10 +21,10 @@ $app             = JFactory::getApplication();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
 	<?php if ($this->direction == 'rtl') : ?>

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -11,6 +11,9 @@ defined('_JEXEC') or die;
 
 $app = JFactory::getApplication();
 
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -19,7 +19,7 @@ require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
 $twofactormethods = UsersHelper::getTwoFactorMethods();
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

Basic conversion of all site and admin templates to HTML5 (some where still XHTML 1.0 Transitional).
#### Testing Instructions
1. Install patch
2. Check if pages in all templates (normal, component, error pages) site and admin are working properly.
#### Observations

All should now start with this code:

``` html
<!DOCTYPE html>
<html lang="en-gb" dir="ltr">
<head>
[...]
    <meta charset="utf-8" />
[...]
```
