### PR TITLE
[JDocument] Allow other attibutes in meta tags

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -378,8 +378,8 @@ class JDocument
 	/**
 	 * Gets a meta tag.
 	 *
-	 * @param   string   $name       Name of the meta HTML tag
-	 * @param   string   $attribute  Attribute to use in the meta HTML tag
+	 * @param   string  $name       Name of the meta HTML tag
+	 * @param   string  $attribute  Attribute to use in the meta HTML tag
 	 *
 	 * @return  string
 	 *
@@ -412,9 +412,9 @@ class JDocument
 	/**
 	 * Sets or alters a meta tag.
 	 *
-	 * @param   string   $name       Name of the meta HTML tag
-	 * @param   string   $content    Value of the meta HTML tag
-	 * @param   string   $attribute  Attribute to use in the meta HTML tag
+	 * @param   string  $name       Name of the meta HTML tag
+	 * @param   string  $content    Value of the meta HTML tag
+	 * @param   string  $attribute  Attribute to use in the meta HTML tag
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -390,7 +390,7 @@ class JDocument
 		// B/C old http_equiv parameter.
 		if (!is_string($attribute))
 		{
-			$attribute = $attribute === true ? 'http-equiv' : 'name';
+			$attribute = $attribute == true ? 'http-equiv' : 'name';
 		}
 
 		if ($name == 'generator')
@@ -425,7 +425,7 @@ class JDocument
 		// B/C old http_equiv parameter.
 		if (!is_string($attribute))
 		{
-			$attribute = $attribute === true ? 'http-equiv' : 'name';
+			$attribute = $attribute == true ? 'http-equiv' : 'name';
 		}
 
 		if ($name == 'generator')

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -378,15 +378,21 @@ class JDocument
 	/**
 	 * Gets a meta tag.
 	 *
-	 * @param   string   $name       Value of name or http-equiv tag
-	 * @param   boolean  $httpEquiv  META type "http-equiv" defaults to null
+	 * @param   string   $name       Name of the meta HTML tag
+	 * @param   string   $attribute  Attribute to use in the meta HTML tag
 	 *
 	 * @return  string
 	 *
 	 * @since   11.1
 	 */
-	public function getMetaData($name, $httpEquiv = false)
+	public function getMetaData($name, $attribute = 'name')
 	{
+		// B/C old http_equiv parameter.
+		if (!is_string($attribute))
+		{
+			$attribute = $attribute === true ? 'http-equiv' : 'name';
+		}
+
 		if ($name == 'generator')
 		{
 			$result = $this->getGenerator();
@@ -397,14 +403,7 @@ class JDocument
 		}
 		else
 		{
-			if ($httpEquiv == true)
-			{
-				$result = @$this->_metaTags['http-equiv'][$name];
-			}
-			else
-			{
-				$result = @$this->_metaTags['standard'][$name];
-			}
+			$result = @$this->_metaTags[$attribute][$name];
 		}
 
 		return $result;
@@ -413,16 +412,22 @@ class JDocument
 	/**
 	 * Sets or alters a meta tag.
 	 *
-	 * @param   string   $name        Value of name or http-equiv tag
-	 * @param   string   $content     Value of the content tag
-	 * @param   boolean  $http_equiv  META type "http-equiv" defaults to null
+	 * @param   string   $name       Name of the meta HTML tag
+	 * @param   string   $content    Value of the meta HTML tag
+	 * @param   string   $attribute  Attribute to use in the meta HTML tag
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
-	public function setMetaData($name, $content, $http_equiv = false)
+	public function setMetaData($name, $content, $attribute = 'name')
 	{
+		// B/C old http_equiv parameter.
+		if (!is_string($attribute))
+		{
+			$attribute = $attribute === true ? 'http-equiv' : 'name';
+		}
+
 		if ($name == 'generator')
 		{
 			$this->setGenerator($content);
@@ -433,14 +438,7 @@ class JDocument
 		}
 		else
 		{
-			if ($http_equiv == true)
-			{
-				$this->_metaTags['http-equiv'][$name] = $content;
-			}
-			else
-			{
-				$this->_metaTags['standard'][$name] = $content;
-			}
+			$this->_metaTags[$attribute][$name] = $content;
 		}
 
 		return $this;

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -47,10 +47,10 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	public function fetchHead($document)
 	{
 		// Convert the tagids to titles
-		if (isset($document->_metaTags['standard']['tags']))
+		if (isset($document->_metaTags['name']['tags']))
 		{
 			$tagsHelper = new JHelperTags;
-			$document->_metaTags['standard']['tags'] = implode(', ', $tagsHelper->getTagNames($document->_metaTags['standard']['tags']));
+			$document->_metaTags['name']['tags'] = implode(', ', $tagsHelper->getTagNames($document->_metaTags['name']['tags']));
 		}
 
 		// Trigger the onBeforeCompileHead event
@@ -86,9 +86,9 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 				{
 					$buffer .= $tab . '<meta http-equiv="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
 				}
-				elseif ($type == 'standard' && !empty($content))
+				elseif (!empty($content))
 				{
-					$buffer .= $tab . '<meta name="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
+					$buffer .= $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

Allow to add other attributes in JDocument::setMetadata and retrieve them with JDocument::getMetadata.
#### Testing Instructions
- Code review
- Add this code in protostar template index.php

``` php
$doc->setMetaData('generator', 'test generator');
$doc->setMetaData('description', 'test description');
$doc->setMetaData('test 1', 'test 1 value');
$doc->setMetaData('test 2', 'test 2 value', true);
$doc->setMetaData('test 3', 'test 3 value', 'property');
$doc->setMetaData('og:image', 'https://cdn.joomla.org/images/Joomla_logo.png', 'property');
```
- Now test before and after patch

Before patch

``` html
  <meta http-equiv="test 2" content="test 2 value" />
  <meta http-equiv="test 3" content="test 3 value" />
  <meta http-equiv="og:image" content="https://cdn.joomla.org/images/Joomla_logo.png" />
  <meta name="test 1" content="test 1 value" />
  <meta name="description" content="test description" />
  <meta name="generator" content="test generator" />
```

After patch

``` html
  <meta http-equiv="test 2" content="test 2 value" />
  <meta name="test 1" content="test 1 value" />
  <meta property="test 3" content="test 3 value" />
  <meta property="og:image" content="https://cdn.joomla.org/images/Joomla_logo.pn" />
  <meta name="description" content="test description" />
  <meta name="generator" content="test generator" />
```
#### B/C

It should be B/C, but since _metaTags is public and don't exactly know the history with this, i'm not sure.
So please confirm the B/C.
