### PR TITLE
Add attribs to the script tag (alternative to 8540)

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -657,19 +657,22 @@ abstract class JHtml
 	/**
 	 * Write a `<script>` element to load a JavaScript file
 	 *
-	 * @param   string   $file            path to file.
-	 * @param   boolean  $framework       load the JS framework.
-	 * @param   boolean  $relative        path to file is relative to /media folder.
-	 * @param   boolean  $path_only       return the path to the file only.
-	 * @param   boolean  $detect_browser  detect browser to include specific browser js files.
-	 * @param   boolean  $detect_debug    detect debug to search for compressed files if debug is on.
+	 * @param   string   $file           Path to file.
+	 * @param   boolean  $framework      Load the JS framework.
+	 * @param   boolean  $relative       Path to file is relative to /media folder.
+	 * @param   boolean  $pathOnly       Return the path to the file only.
+	 * @param   boolean  $detectBrowser  Detect browser to include specific browser js files.
+	 * @param   boolean  $detectDebug    Detect debug to search for compressed files if debug is on.
+	 * @param   string   $version        Version of the script. null to auto generate.
+	 * @param   array    $attribs        Attributes of the script tag.
 	 *
 	 * @return  mixed  nothing if $path_only is false, null, path or array of path if specific js browser files were detected.
 	 *
 	 * @see     JHtml::stylesheet()
 	 * @since   1.5
 	 */
-	public static function script($file, $framework = false, $relative = false, $path_only = false, $detect_browser = true, $detect_debug = true)
+	public static function script($file, $framework = false, $relative = false, $pathOnly = false, $detectBrowser = true, $detectDebug = true,
+		$version = '', $attribs = array()))
 	{
 		// Include MooTools framework
 		if ($framework)
@@ -702,7 +705,7 @@ abstract class JHtml
 
 			foreach ($includes as $include)
 			{
-				$document->addScript($include);
+				$document->addScriptVersion($include, $version, $attribs);
 			}
 		}
 	}

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -672,7 +672,7 @@ abstract class JHtml
 	 * @since   1.5
 	 */
 	public static function script($file, $framework = false, $relative = false, $pathOnly = false, $detectBrowser = true, $detectDebug = true,
-		$version = '', $attribs = array()))
+		$version = '', $attribs = array())
 	{
 		// Include MooTools framework
 		if ($framework)
@@ -680,10 +680,10 @@ abstract class JHtml
 			static::_('behavior.framework');
 		}
 
-		$includes = static::includeRelativeFiles('js', $file, $relative, $detect_browser, $detect_debug);
+		$includes = static::includeRelativeFiles('js', $file, $relative, $detectBrowser, $detectDebug);
 
 		// If only path is required
-		if ($path_only)
+		if ($pathOnly)
 		{
 			if (count($includes) == 0)
 			{

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -447,20 +447,38 @@ class JDocument
 	/**
 	 * Adds a linked script to the page
 	 *
-	 * @param   string   $url    URL to the linked script
-	 * @param   string   $type   Type of script. Defaults to 'text/javascript'
-	 * @param   boolean  $defer  Adds the defer attribute.
-	 * @param   boolean  $async  Adds the async attribute.
+	 * @param   string   $url      URL to the linked script.
+	 * @param   array    $attribs  Array of attributes.
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
-	public function addScript($url, $type = "text/javascript", $defer = false, $async = false)
+	public function addScript($url, $attribs = array())
 	{
-		$this->_scripts[$url]['mime'] = $type;
-		$this->_scripts[$url]['defer'] = $defer;
-		$this->_scripts[$url]['async'] = $async;
+		// B/C before __DEPLOY_VERSION__
+		if (!is_array($attribs))
+		{
+			$argList = func_get_args();
+			$attribs = array();
+
+			if (!empty($argList[1]))
+			{
+				$attribs['type'] = $argList[1];
+			}
+
+			if (isset($argList[2]) && $argList[2])
+			{
+				$attribs['defer'] = 'defer';
+			}
+
+			if (isset($argList[3]) && $argList[3])
+			{
+				$attribs['async'] = 'async';
+			}
+		}
+
+		$this->_scripts[$url]['attribs'] = isset($this->_scripts[$url]['attribs']) ? array_replace($this->_scripts[$url]['attribs'], $attribs) : $attribs;
 
 		return $this;
 	}
@@ -469,17 +487,15 @@ class JDocument
 	 * Adds a linked script to the page with a version to allow to flush it. Ex: myscript.js54771616b5bceae9df03c6173babf11d
 	 * If not specified Joomla! automatically handles versioning
 	 *
-	 * @param   string   $url      URL to the linked script
-	 * @param   string   $version  Version of the script
-	 * @param   string   $type     Type of script. Defaults to 'text/javascript'
-	 * @param   boolean  $defer    Adds the defer attribute.
-	 * @param   boolean  $async    [description]
+	 * @param   string   $url      URL to the linked script.
+	 * @param   string   $version  Version of the script.
+	 * @param   array    $attribs  Array of attributes.
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   3.2
 	 */
-	public function addScriptVersion($url, $version = null, $type = "text/javascript", $defer = false, $async = false)
+	public function addScriptVersion($url, $version = null, $attribs = array())
 	{
 		// Automatic version
 		if ($version === null)
@@ -492,7 +508,30 @@ class JDocument
 			$url .= '?' . $version;
 		}
 
-		return $this->addScript($url, $type, $defer, $async);
+		// B/C before __DEPLOY_VERSION__
+		// @deprecated 4.0 Use addScriptVersion($url, $version, array('attrib' => 'value', ...));
+		if (!is_array($attribs))
+		{
+			$argList = func_get_args();
+			$attribs = array();
+
+			if (!empty($argList[2]))
+			{
+				$attribs['type'] = $argList[2];
+			}
+
+			if (isset($argList[3]) && $argList[3])
+			{
+				$attribs['defer'] = 'defer';
+			}
+
+			if (isset($argList[4]) && $argList[4])
+			{
+				$attribs['async'] = 'async';
+			}
+		}
+
+		return $this->addScript($url, $attribs);
 	}
 
 	/**

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -457,6 +457,7 @@ class JDocument
 	public function addScript($url, $attribs = array())
 	{
 		// B/C before __DEPLOY_VERSION__
+		// @deprecated 4.0 Use addScript($url, array('attrib' => 'value', ...));
 		if (!is_array($attribs))
 		{
 			$argList = func_get_args();

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -191,19 +191,33 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		{
 			$buffer .= $tab . '<script src="' . $strSrc . '"';
 
-			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultJsMimes)))
+			// Populate old data for B/C.
+			// @deprecated 4.0 Use addScript('url', array('attrib' => 'value', ...));
+			if (isset($strAttr['mime']) && !is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultMimes)))
 			{
 				$buffer .= ' type="' . $strAttr['mime'] . '"';
 			}
 
-			if ($strAttr['defer'])
+			if (isset($strAttr['defer']) && $strAttr['defer'])
 			{
 				$buffer .= ' defer="defer"';
 			}
 
-			if ($strAttr['async'])
+			if (isset($strAttr['async']) && $strAttr['async'])
 			{
 				$buffer .= ' async="async"';
+			}
+
+			// Add script tag attributes.
+			foreach ($strAttr['attribs'] as $attrib => $value)
+			{
+				// Don't add type attribute if document is HTML5 and it's a default mime type.
+				if ($attrib === 'type' && $document->isHtml5() && in_array($value, $defaultMimes))
+				{
+					continue;
+				}
+
+				$buffer .= ' ' . htmlspecialchars($attrib) . '="' . (is_scalar($value) ? htmlspecialchars($value) : htmlspecialchars(json_encode($value)) ) . '"';
 			}
 
 			$buffer .= '></script>' . $lnEnd;

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -193,7 +193,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 			// Populate old data for B/C.
 			// @deprecated 4.0 Use addScript('url', array('attrib' => 'value', ...));
-			if (isset($strAttr['mime']) && !is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultMimes)))
+			if (isset($strAttr['mime']) && !is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultJsMimes)))
 			{
 				$buffer .= ' type="' . $strAttr['mime'] . '"';
 			}
@@ -212,7 +212,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			foreach ($strAttr['attribs'] as $attrib => $value)
 			{
 				// Don't add type attribute if document is HTML5 and it's a default mime type.
-				if ($attrib === 'type' && $document->isHtml5() && in_array($value, $defaultMimes))
+				if ($attrib === 'type' && $document->isHtml5() && in_array($value, $defaultJsMimes))
 				{
 					continue;
 				}


### PR DESCRIPTION
#### Summary of Changes

This PR (alternative to 8540) adds the ability to add more attributes to the script tag using `JDocument::addScript()`, `JDocument::addScriptVersion()` and `JHtml::script()` methods.

Also adds the ability to add the script version when using `JHtml::script()` method.
#### How to test

Please test this in all possible scenarios.
Any problem will get scripts not laoding.
- Use latest staging
- Apply patch
- Check backend and frontend are working fine
- Add external js scripts like to isis/protostar index.php, some examples:

``` php
// JDocument B/C tests
$this->addScript('/path/to/external/bcaddScript1.js');
$this->addScript('/path/to/external/bcaddScript2.js', '', true, false);
$this->addScript('/path/to/external/bcaddScript3.js', 'text/javascript', true, true);
$this->addScriptVersion('/path/to/external/bcaddScriptVersion1.js');
$this->addScriptVersion('/path/to/external/bcaddScriptVersion2.js', null, '', true, false);
$this->addScriptVersion('/path/to/external/bcaddScriptVersion3.js', 'version-string', 'text/javascript', true, true);

// JDocument new method tests
$this->addScript('/path/to/external/addScript1.js', array('id' => 'scriptid'));
$this->addScript('/path/to/external/addScript2.js', array('id' => 'scriptid', 'data-test' => 1));
$this->addScript('/path/to/external/addScript3.js', array('data-attrib' => 5));
$this->addScript('/path/to/external/addScript4.js', array('data-attrib' => array('item1' => 'version-string', 'item2' => 'value2')));
$this->addScriptVersion('/path/to/external/addScriptVersion5.js', null, array('id' => 'scriptid'));
$this->addScriptVersion('/path/to/external/addScriptVersion6.js', 'version-string', array('id' => 'scriptid'));

// JHTML B/C Tests
JHtml::_('script', 'system/multiselect.js');
JHtml::_('script', 'system/repeatable.js', false, true, false, false, true);

// JHtml extended method (attribs + version) Tests
JHtml::_('script', 'system/progressbar.js', false, true, false, false, true, '', array('data-attrib' => array('item1' => 3, 'item2' => 'value2')));
JHtml::_('script', 'system/permissions.js', false, true, false, false, true, null, array('data-attrib' => array('item1' => 3, 'item2' => 'value2')));
JHtml::_('script', 'system/sendtestmail.js', false, true, false, false, true, 'version-string', array('async' => 'async', 'defer' => 'defer', 'data-attrib' => array('item1' => 3, 'item2' => 'value2')));
```
- Check the HTML output and confirm all is fine
- Do a code review.
#### B/C

None that i know of.
