### PR TITLE
Add exception PoC

### DIFF
--- a/administrator/components/com_plugins/plugins.php
+++ b/administrator/components/com_plugins/plugins.php
@@ -12,7 +12,9 @@ JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_plugins'))
 {
-	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	JLoader::register('JControllerExceptionNotAllowed', JPATH_PLATFORM . '/joomla/controller/exception/notallowed.php');
+
+	throw new JControllerExceptionNotAllowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }
 
 $controller = JControllerLegacy::getInstance('Plugins');

--- a/administrator/components/com_plugins/plugins.php
+++ b/administrator/components/com_plugins/plugins.php
@@ -12,9 +12,7 @@ JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_plugins'))
 {
-	JLoader::register('JControllerExceptionNotAllowed', JPATH_PLATFORM . '/joomla/controller/exception/notallowed.php');
-
-	throw new JControllerExceptionNotAllowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
+	throw new JControllerExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }
 
 $controller = JControllerLegacy::getInstance('Plugins');

--- a/libraries/joomla/controller/exception/notallowed.php
+++ b/libraries/joomla/controller/exception/notallowed.php
@@ -14,6 +14,6 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  __DEPLOY_VERSION__
  */
-class JControllerExceptionNotAllowed extends RuntimeException
+class JControllerExceptionNotallowed extends RuntimeException
 {
 }

--- a/libraries/joomla/controller/exception/notallowed.php
+++ b/libraries/joomla/controller/exception/notallowed.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Controller
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Exception class defining an not allowed controller access
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JControllerExceptionNotAllowed extends RuntimeException
+{
+}


### PR DESCRIPTION
This a PoC for adding a custom exception.

> Well, if there isn't something in the standard SPL exceptions, just add a custom class like we have in the database API.

I'm new to this exception things so @mbabker please i ask you to review this code.

This basicly is adding a custom exception JControllerExceptionNotAllowed to apply to all components.
Is this the way to do it? 

I add to use JLoader because the exception class  is not autoloaded in the error page.
