### PR TITLE
modals for categories (adicional for 3.7 branch)

### DIFF
--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -27,7 +27,9 @@
 			type="modal_category"
 			extension="com_users"
 			label="COM_USERS_FIELD_CATEGORY_ID_LABEL"
-			description="JFIELD_CATEGORY_DESC" 
+			description="JFIELD_CATEGORY_DESC"
+			select="true"
+			new="true"
 			edit="true"
 			clear="true"
 		>

--- a/components/com_contact/views/category/tmpl/default.xml
+++ b/components/com_contact/views/category/tmpl/default.xml
@@ -22,9 +22,10 @@
 				label="COM_CONTACT_FIELD_CATEGORY_LABEL"
 				description="COM_CONTACT_FIELD_CATEGORY_DESC"
 				extension="com_contact"
-				required="true"
+				select="true"
+				new="true"
 				edit="true"
-				clear="false"
+				clear="true"
 			/>
 		</fieldset>
 	</fields>

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -18,9 +18,10 @@
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
 				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
 				extension="com_content"
-				required="true"
+				select="true"
+				new="true"
 				edit="true"
-				clear="false"
+				clear="true"
 			/>
 		</fieldset>
 	</fields>

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -20,9 +20,10 @@
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
 				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
 				extension="com_content"
-				required="true"
+				select="true"
+				new="true"
 				edit="true"
-				clear="false"
+				clear="true"
 			/>
 		</fieldset>
 	</fields>

--- a/components/com_newsfeeds/views/category/tmpl/default.xml
+++ b/components/com_newsfeeds/views/category/tmpl/default.xml
@@ -22,9 +22,10 @@
 				label="JCATEGORY"
 				description="COM_NEWSFEEDS_FIELD_SELECT_CATEGORY_DESC"
 				extension="com_newsfeeds"
-				required="true"
+				select="true"
+				new="true"
 				edit="true"
-				clear="false"
+				clear="true"
 			/>
 		</fieldset>
 	</fields>

--- a/modules/mod_articles_categories/mod_articles_categories.xml
+++ b/modules/mod_articles_categories/mod_articles_categories.xml
@@ -31,9 +31,10 @@
 					description="MOD_ARTICLES_CATEGORIES_FIELD_PARENT_DESC"
 					extension="com_content"
 					published=""
-					required="true"
+					select="true"
+					new="true"
 					edit="true"
-					clear="false"
+					clear="true"
 				/>
 
 				<field


### PR DESCRIPTION
Pull Request for Improvement.
### Summary of Changes

This is the last PR (i hope) of this sequence.

Thsi is only adds the button in the xmls of fields that in 3,7,x branch use now the category modal and it's a sequence of https://github.com/joomla/joomla-cms/pull/11857.
### Testing Instructions
- Use joomla latest **3.7.x branch**
- Apply this patch
- Test the new modal buttons behaviour in:
  - "Category List" Menu item type, 
  - "Category Blog" Menu item type, 
  - "List Contacts in a Category" Menu item type
  - "List News Feeds in a Category" Menu item type, 
  - New/Edit "User Note", "Category" field 
  - New/Edit "Articles - Categories" Module, "Category" field
- Test the "Edit", "Create", "Select" and "Clear" buttons
- Code review to check all is ok.
### Documentation Changes Required

None.
