### PR TITLE
Detach language switcher from site app

### DIFF
--- a/administrator/components/com_languages/controllers/installed.php
+++ b/administrator/components/com_languages/controllers/installed.php
@@ -31,16 +31,6 @@ class LanguagesControllerInstalled extends JControllerLegacy
 
 		if ($model->publish($cid))
 		{
-			// Switching to the new administrator language for the message
-			if ($model->getState('client_id') == 1)
-			{
-				$language = JFactory::getLanguage();
-				$newLang = JLanguage::getInstance($cid);
-				JFactory::$language = $newLang;
-				JFactory::getApplication()->loadLanguage($language = $newLang);
-				$newLang->load('com_languages', JPATH_ADMINISTRATOR);
-			}
-
 			$msg = JText::_('COM_LANGUAGES_MSG_DEFAULT_LANGUAGE_SAVED');
 			$type = 'message';
 		}
@@ -75,11 +65,7 @@ class LanguagesControllerInstalled extends JControllerLegacy
 		if ($model->switchAdminLanguage($cid))
 		{
 			// Switching to the new language for the message
-			$language = JFactory::getLanguage();
-			$newLang = JLanguage::getInstance($cid);
-			JFactory::$language = $newLang;
-			JFactory::getApplication()->loadLanguage($language = $newLang);
-			$newLang->load('com_languages', JPATH_ADMINISTRATOR);
+			JFactory::getApplication()->setLanguage($cid);
 
 			$msg = JText::sprintf('COM_LANGUAGES_MSG_SWITCH_ADMIN_LANGUAGE_SUCCESS', $languageName);
 			$type = 'message';

--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -493,11 +493,9 @@ class LanguagesModelInstalled extends JModelList
 	{
 		if ($cid)
 		{
-			$client = $this->getClient();
-
-			if ($client->name == 'administrator')
+			if ($this->getClient()->name == 'administrator')
 			{
-				JFactory::getApplication()->setUserState('application.lang', $cid);
+				JFactory::getApplication()->setUserState('language', $cid);
 			}
 		}
 		else

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -238,6 +238,39 @@ class JApplicationAdministrator extends JApplicationCms
 	}
 
 	/**
+	 * Get the application language code.
+	 *
+	 * @return  string  App language code.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getLanguageCode()
+	{
+		$language = null;
+
+		// Check the user language.
+		if (is_null($language) && $lang = JFactory::getUser()->getParam('admin_language'))
+		{
+			$language = JLanguage::exists($lang) ? $lang : null;
+		}
+
+		// Check the default language
+		if (is_null($language) && $lang = JComponentHelper::getParams('com_languages')->get('administrator', 'en-GB'))
+		{
+			$language = JLanguage::exists($lang) ? $lang : null;
+		}
+
+		// Check the config language
+		if (is_null($language) && $lang = $this->config->get('language', 'en-GB'))
+		{
+			$language = JLanguage::exists($lang) ? $lang : null;
+		}
+
+		// Return the language or fallback to en-GB.
+		return !is_null($language) ? $language : 'en-GB';
+	}
+
+	/**
 	 * Initialise the application.
 	 *
 	 * @param   array  $options  An optional associative array of configuration settings.
@@ -257,38 +290,8 @@ class JApplicationAdministrator extends JApplicationCms
 			$user->groups = array($guestUsergroup);
 		}
 
-		// If a language was specified it has priority, otherwise use user or default language settings
-		if (empty($options['language']))
-		{
-			$lang = $user->getParam('admin_language');
-
-			// Make sure that the user's language exists
-			if ($lang && JLanguage::exists($lang))
-			{
-				$options['language'] = $lang;
-			}
-			else
-			{
-				$params = JComponentHelper::getParams('com_languages');
-				$options['language'] = $params->get('administrator', $this->get('language', 'en-GB'));
-			}
-		}
-
-		// One last check to make sure we have something
-		if (!JLanguage::exists($options['language']))
-		{
-			$lang = $this->get('language', 'en-GB');
-
-			if (JLanguage::exists($lang))
-			{
-				$options['language'] = $lang;
-			}
-			else
-			{
-				// As a last ditch fail to english
-				$options['language'] = 'en-GB';
-			}
-		}
+		// Get the app language.
+		$options['language'] = $this->getLanguageCode();
 
 		// Finish initialisation
 		parent::initialiseApp($options);

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -260,14 +260,14 @@ class JApplicationAdministrator extends JApplicationCms
 			$language = JLanguage::exists($lang) ? $lang : null;
 		}
 
-		// Check the config language
+		// Check the config language or fallback to en-GB.
 		if (is_null($language) && $lang = $this->config->get('language', 'en-GB'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : null;
+			$language = JLanguage::exists($lang) ? $lang : 'en-GB';
 		}
 
-		// Return the language or fallback to en-GB.
-		return !is_null($language) ? $language : 'en-GB';
+		// Return the language.
+		return $language;
 	}
 
 	/**

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -249,7 +249,7 @@ class JApplicationAdministrator extends JApplicationCms
 		$languageCode = null;
 
 		// Check the user language.
-		if (is_null($language) && $lang = JFactory::getUser()->getParam('admin_language'))
+		if (is_null($languageCode) && $lang = JFactory::getUser()->getParam('admin_language'))
 		{
 			$languageCode = JLanguage::exists($lang) ? $lang : null;
 		}

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -113,7 +113,7 @@ class JApplicationAdministrator extends JApplicationCms
 	protected function doExecute()
 	{
 		// Initialise the application
-		$this->initialiseApp(array('language' => $this->getUserState('application.lang')));
+		$this->initialiseApp();
 
 		// Test for magic quotes
 		if (get_magic_quotes_gpc())
@@ -258,27 +258,27 @@ class JApplicationAdministrator extends JApplicationCms
 		}
 
 		// If app language is not yet set, check the user language.
-		if (empty($options['language']) && $lang = $this->getUserState('language', 'en-GB'))
+		if (empty($options['language']) && $lang = $this->getUserState('language', ''))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : '';
 		}
 
 		// Check the user params language.
-		if (empty($options['language']) && $lang = JFactory::getUser()->getParam('admin_language'))
+		if (empty($options['language']) && $lang = $user->getParam('admin_language'))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : '';
 		}
 
 		// Check the default language.
-		if (empty($options['language']) && $lang = JComponentHelper::getParams('com_languages')->get('administrator', 'en-GB'))
+		if (empty($options['language']) && $lang = JComponentHelper::getParams('com_languages')->get('administrator', ''))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : '';
 		}
 
 		// Check the config language or fallback to en-GB.
-		if (empty($options['language']) && $lang = $this->config->get('language', 'en-GB'))
+		if (empty($options['language']) && $lang = $this->config->get('language', ''))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : 'en-GB';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : 'en-GB';
 		}
 
 		// Finish initialisation.
@@ -321,7 +321,7 @@ class JApplicationAdministrator extends JApplicationCms
 
 			if ($lang)
 			{
-				$this->setUserState('application.lang', $lang);
+				$this->setUserState('language', $lang);
 			}
 
 			static::purgeMessages();

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -238,39 +238,6 @@ class JApplicationAdministrator extends JApplicationCms
 	}
 
 	/**
-	 * Get the application language code.
-	 *
-	 * @return  string  App language code.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected function getLanguageCode()
-	{
-		$languageCode = null;
-
-		// Check the user language.
-		if (is_null($languageCode) && $lang = JFactory::getUser()->getParam('admin_language'))
-		{
-			$languageCode = JLanguage::exists($lang) ? $lang : null;
-		}
-
-		// Check the default language
-		if (is_null($languageCode) && $lang = JComponentHelper::getParams('com_languages')->get('administrator', 'en-GB'))
-		{
-			$languageCode = JLanguage::exists($lang) ? $lang : null;
-		}
-
-		// Check the config language or fallback to en-GB.
-		if (is_null($languageCode) && $lang = $this->config->get('language', 'en-GB'))
-		{
-			$languageCode = JLanguage::exists($lang) ? $lang : 'en-GB';
-		}
-
-		// Return the language.
-		return $languageCode;
-	}
-
-	/**
 	 * Initialise the application.
 	 *
 	 * @param   array  $options  An optional associative array of configuration settings.
@@ -290,13 +257,25 @@ class JApplicationAdministrator extends JApplicationCms
 			$user->groups = array($guestUsergroup);
 		}
 
-		// Get the app language code only if app language is not yet set.
-		if (empty($options['language']))
+		// If app language is not yet set, check the user language.
+		if (empty($options['language']) && $lang = JFactory::getUser()->getParam('admin_language'))
 		{
-			$options['language'] = $this->getLanguageCode();
+			$options['language'] = JLanguage::exists($lang) ? $lang : '';
 		}
 
-		// Finish initialisation
+		// Check the default language.
+		if (empty($options['language']) && $lang = JComponentHelper::getParams('com_languages')->get('administrator', 'en-GB'))
+		{
+			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+		}
+
+		// Check the config language or fallback to en-GB.
+		if (empty($options['language']) && $lang = $this->config->get('language', 'en-GB'))
+		{
+			$options['language'] = JLanguage::exists($lang) ? $lang : 'en-GB';
+		}
+
+		// Finish initialisation.
 		parent::initialiseApp($options);
 	}
 

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -263,7 +263,7 @@ class JApplicationAdministrator extends JApplicationCms
 			$options['language'] = JLanguage::exists($lang) ? $lang : '';
 		}
 
-		// ICheck the user params language.
+		// Check the user params language.
 		if (empty($options['language']) && $lang = JFactory::getUser()->getParam('admin_language'))
 		{
 			$options['language'] = JLanguage::exists($lang) ? $lang : '';

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -246,28 +246,28 @@ class JApplicationAdministrator extends JApplicationCms
 	 */
 	protected function getLanguageCode()
 	{
-		$language = null;
+		$languageCode = null;
 
 		// Check the user language.
 		if (is_null($language) && $lang = JFactory::getUser()->getParam('admin_language'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : null;
+			$languageCode = JLanguage::exists($lang) ? $lang : null;
 		}
 
 		// Check the default language
-		if (is_null($language) && $lang = JComponentHelper::getParams('com_languages')->get('administrator', 'en-GB'))
+		if (is_null($languageCode) && $lang = JComponentHelper::getParams('com_languages')->get('administrator', 'en-GB'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : null;
+			$languageCode = JLanguage::exists($lang) ? $lang : null;
 		}
 
 		// Check the config language or fallback to en-GB.
-		if (is_null($language) && $lang = $this->config->get('language', 'en-GB'))
+		if (is_null($languageCode) && $lang = $this->config->get('language', 'en-GB'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : 'en-GB';
+			$languageCode = JLanguage::exists($lang) ? $lang : 'en-GB';
 		}
 
 		// Return the language.
-		return $language;
+		return $languageCode;
 	}
 
 	/**
@@ -291,7 +291,7 @@ class JApplicationAdministrator extends JApplicationCms
 		}
 
 		// Get the app language code only if app language is not yet set.
-		if (empty($options['language']) && is_null($this->get('language', null)))
+		if (empty($options['language']))
 		{
 			$options['language'] = $this->getLanguageCode();
 		}

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -290,8 +290,11 @@ class JApplicationAdministrator extends JApplicationCms
 			$user->groups = array($guestUsergroup);
 		}
 
-		// Get the app language.
-		$options['language'] = $this->getLanguageCode();
+		// Get the app language code only if app language is not yet set.
+		if (empty($options['language']) && is_null($this->get('language', null)))
+		{
+			$options['language'] = $this->getLanguageCode();
+		}
 
 		// Finish initialisation
 		parent::initialiseApp($options);

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -258,6 +258,12 @@ class JApplicationAdministrator extends JApplicationCms
 		}
 
 		// If app language is not yet set, check the user language.
+		if (empty($options['language']) && $lang = $this->getUserState('language', 'en-GB'))
+		{
+			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+		}
+
+		// ICheck the user params language.
 		if (empty($options['language']) && $lang = JFactory::getUser()->getParam('admin_language'))
 		{
 			$options['language'] = JLanguage::exists($lang) ? $lang : '';

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -664,7 +664,7 @@ class JApplicationCms extends JApplicationWeb
 
 		$this->set('editor', $editor);
 
-		// Run onAfterInitialise event.
+		// Trigger the onAfterInitialise event.
 		JPluginHelper::importPlugin('system');
 		$this->triggerEvent('onAfterInitialise');
 	}

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -628,8 +628,8 @@ class JApplicationCms extends JApplicationWeb
 	 */
 	protected function initialiseApp($options = array())
 	{
-		// Check that we were given a language in the array (since by default may be blank).
-		if (isset($options['language']) && !$this->get('language', ''))
+		// Check that we were given a language in the array (since by default may be blank) and if the language is not already set.
+		if (isset($options['language']) && is_null($this->get('language', null)))
 		{
 			$this->set('language', $options['language']);
 		}

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -628,8 +628,8 @@ class JApplicationCms extends JApplicationWeb
 	 */
 	protected function initialiseApp($options = array())
 	{
-		// Check that we were given a language in the array (since by default may be blank) and if the language is not already set.
-		if (isset($options['language']) && is_null($this->get('language', null)))
+		// Check that we were given a language in the array (since by default may be blank).
+		if (isset($options['language']))
 		{
 			$this->set('language', $options['language']);
 		}

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -634,6 +634,9 @@ class JApplicationCms extends JApplicationWeb
 			$this->set('language', $options['language']);
 		}
 
+		// Set the user language.
+		$this->setUserState('language', $this->get('language'));
+
 		// Build our language object
 		$lang = JLanguage::getInstance($this->get('language'), $this->get('debug_lang'));
 

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -865,6 +865,9 @@ class JApplicationCms extends JApplicationWeb
 				}
 			}
 
+			// Set the user language.
+			$this->setUserState('language', $response->language);
+
 			// OK, the credentials are authenticated and user is authorised.  Let's fire the onLogin event.
 			$results = $this->triggerEvent('onUserLogin', array((array) $response, $options));
 

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -629,7 +629,7 @@ class JApplicationCms extends JApplicationWeb
 	protected function initialiseApp($options = array())
 	{
 		// Check that we were given a language in the array (since by default may be blank).
-		if (isset($options['language']))
+		if (isset($options['language']) && !$this->get('language', ''))
 		{
 			$this->set('language', $options['language']);
 		}

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -647,8 +647,7 @@ class JApplicationCms extends JApplicationWeb
 		$this->loadLibraryLanguage();
 
 		// Set user specific editor.
-		$user = JFactory::getUser();
-		$editor = $user->getParam('editor', $this->get('editor'));
+		$editor = JFactory::getUser()->getParam('editor', $this->get('editor'));
 
 		if (!JPluginHelper::isEnabled('editors', $editor))
 		{
@@ -662,7 +661,7 @@ class JApplicationCms extends JApplicationWeb
 
 		$this->set('editor', $editor);
 
-		// Trigger the onAfterInitialise event.
+		// Run onAfterInitialise event.
 		JPluginHelper::importPlugin('system');
 		$this->triggerEvent('onAfterInitialise');
 	}

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -207,10 +207,10 @@ final class JApplicationSite extends JApplicationCms
 	{
 		// Run before initialize event for allowing to set the language.
 		JPluginHelper::importPlugin('system');
-		$this->triggerEvent('languageSet');
+		$this->triggerEvent('onBeforeLanguage');
 
 		// Mark beforeInitialise in the profiler.
-		JDEBUG ? $this->profiler->mark('languageSet') : null;
+		JDEBUG ? $this->profiler->mark('beforeLanguage') : null;
 
 		// Initialise the application
 		$this->initialiseApp();

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -593,31 +593,31 @@ final class JApplicationSite extends JApplicationCms
 		// If app language is not yet set, check the url parameters.
 		if (empty($options['language']) && $lang = $this->input->get('language', '', 'string'))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : '';
 		}
 
 		// Check the user language.
-		if (empty($options['language']) && $lang = $this->getUserState('language', 'en-GB'))
+		if (empty($options['language']) && $lang = $this->getUserState('language', ''))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : '';
 		}
 
 		// Check the user params language.
-		if (empty($options['language']) && $lang = JFactory::getUser()->getParam('language'))
+		if (empty($options['language']) && $lang = $user->getParam('language'))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : '';
 		}
 
 		// Check the default language.
-		if (empty($options['language']) && $lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
+		if (empty($options['language']) && $lang = JComponentHelper::getParams('com_languages')->get('site', ''))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : '';
 		}
 
 		// Check the config language or fallback to en-GB.
-		if (empty($options['language']) && $lang = $this->config->get('language', 'en-GB'))
+		if (empty($options['language']) && $lang = $this->config->get('language', ''))
 		{
-			$options['language'] = JLanguage::exists($lang) ? $lang : 'en-GB';
+			$options['language'] = $lang && JLanguage::exists($lang) ? $lang : 'en-GB';
 		}
 
 		// Finish initialisation.

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -571,45 +571,6 @@ final class JApplicationSite extends JApplicationCms
 	}
 
 	/**
-	 * Get the application language code.
-	 *
-	 * @return  string  App language code.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected function getLanguageCode()
-	{
-		$languageCode = null;
-
-		// Check the url parameters
-		if ($lang = $this->input->get('language', '', 'string'))
-		{
-			$languageCode = JLanguage::exists($lang) ? $lang : null;
-		}
-
-		// Check the user language.
-		if (is_null($languageCode) && $lang = JFactory::getUser()->getParam('language'))
-		{
-			$languageCode = JLanguage::exists($lang) ? $lang : null;
-		}
-
-		// Check the default language
-		if (is_null($languageCode) && $lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
-		{
-			$languageCode = JLanguage::exists($lang) ? $lang : null;
-		}
-
-		// Check the config language or fallback to en-GB.
-		if (is_null($languageCode) && $lang = $this->config->get('language', 'en-GB'))
-		{
-			$languageCode = JLanguage::exists($lang) ? $lang : 'en-GB';
-		}
-
-		// Return the language code.
-		return $languageCode;
-	}
-
-	/**
 	 * Initialise the application.
 	 *
 	 * @param   array  $options  An optional associative array of configuration settings.
@@ -629,13 +590,31 @@ final class JApplicationSite extends JApplicationCms
 			$user->groups = array($guestUsergroup);
 		}
 
-		// Get the app language code only if app language is not yet set.
-		if (empty($options['language']))
+		// If app language is not yet set, check the url parameters.
+		if (empty($options['language']) && $lang = $this->input->get('language', '', 'string'))
 		{
-			$options['language'] = $this->getLanguageCode();
+			$options['language'] = JLanguage::exists($lang) ? $lang : '';
 		}
 
-		// Finish initialisation
+		// Check the user language.
+		if (empty($options['language']) && $lang = JFactory::getUser()->getParam('language'))
+		{
+			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+		}
+
+		// Check the default language.
+		if (empty($options['language']) && $lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
+		{
+			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+		}
+
+		// Check the config language or fallback to en-GB.
+		if (empty($options['language']) && $lang = $this->config->get('language', 'en-GB'))
+		{
+			$options['language'] = JLanguage::exists($lang) ? $lang : 'en-GB';
+		}
+
+		// Finish initialisation.
 		parent::initialiseApp($options);
 	}
 

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -636,8 +636,8 @@ final class JApplicationSite extends JApplicationCms
 			$user->groups = array($guestUsergroup);
 		}
 
-		// Set the language only if not yet set.
-		if (!$this->get('language', ''))
+		// Get the app language code only if app language is not yet set.
+		if (empty($options['language']) && is_null($this->get('language', null)))
 		{
 			$options['language'] = $this->getLanguageCode();
 		}

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -597,6 +597,12 @@ final class JApplicationSite extends JApplicationCms
 		}
 
 		// Check the user language.
+		if (empty($options['language']) && $lang = $this->getUserState('language', 'en-GB'))
+		{
+			$options['language'] = JLanguage::exists($lang) ? $lang : '';
+		}
+
+		// Check the user params language.
 		if (empty($options['language']) && $lang = JFactory::getUser()->getParam('language'))
 		{
 			$options['language'] = JLanguage::exists($lang) ? $lang : '';

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -205,13 +205,6 @@ final class JApplicationSite extends JApplicationCms
 	 */
 	protected function doExecute()
 	{
-		// Run before initialize event for allowing to set the language.
-		JPluginHelper::importPlugin('system');
-		$this->triggerEvent('onBeforeLanguage');
-
-		// Mark beforeInitialise in the profiler.
-		JDEBUG ? $this->profiler->mark('beforeLanguage') : null;
-
 		// Initialise the application
 		$this->initialiseApp();
 
@@ -586,34 +579,34 @@ final class JApplicationSite extends JApplicationCms
 	 */
 	protected function getLanguageCode()
 	{
-		$language = null;
+		$languageCode = null;
 
 		// Check the url parameters
 		if ($lang = $this->input->get('language', '', 'string'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : null;
+			$languageCode = JLanguage::exists($lang) ? $lang : null;
 		}
 
 		// Check the user language.
-		if (!$language && $lang = JFactory::getUser()->getParam('language'))
+		if (is_null($languageCode) && $lang = JFactory::getUser()->getParam('language'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : null;
+			$languageCode = JLanguage::exists($lang) ? $lang : null;
 		}
 
 		// Check the default language
-		if (!$language && $lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
+		if (is_null($languageCode) && $lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : null;
+			$languageCode = JLanguage::exists($lang) ? $lang : null;
 		}
 
 		// Check the config language or fallback to en-GB.
-		if (!$language && $lang = $this->config->get('language', 'en-GB'))
+		if (is_null($languageCode) && $lang = $this->config->get('language', 'en-GB'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : 'en-GB';
+			$languageCode = JLanguage::exists($lang) ? $lang : 'en-GB';
 		}
 
-		// Return the language.
-		return $language;
+		// Return the language code.
+		return $languageCode;
 	}
 
 	/**
@@ -637,7 +630,7 @@ final class JApplicationSite extends JApplicationCms
 		}
 
 		// Get the app language code only if app language is not yet set.
-		if (empty($options['language']) && is_null($this->get('language', null)))
+		if (empty($options['language']))
 		{
 			$options['language'] = $this->getLanguageCode();
 		}

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -606,14 +606,14 @@ final class JApplicationSite extends JApplicationCms
 			$language = JLanguage::exists($lang) ? $lang : null;
 		}
 
-		// Check the config language
+		// Check the config language or fallback to en-GB.
 		if (!$language && $lang = $this->config->get('language', 'en-GB'))
 		{
-			$language = JLanguage::exists($lang) ? $lang : null;
+			$language = JLanguage::exists($lang) ? $lang : 'en-GB';
 		}
 
-		// Return the language or fallback to en-GB.
-		return !is_null($language) ? $language : 'en-GB';
+		// Return the language.
+		return $language;
 	}
 
 	/**

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -115,6 +115,60 @@ class PlgSystemLanguageFilter extends JPlugin
 	}
 
 	/**
+	 * On language set event.
+	 *
+	 * @return  string  App language code.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onLanguageSet()
+	{
+		if ($this->app->isSite())
+		{
+			$language = null;
+
+			// Check the url parameters
+			if ($lang = $this->app->input->get('language', '', 'string'))
+			{
+				$language = JLanguage::exists($lang) ? $lang : null;
+			}
+
+			// Check the language cookie
+			if (!$language && $lang = $this->app->input->cookie->get(md5($this->get('secret') . 'language'), null, 'string'))
+			{
+				$language = JLanguage::exists($lang) ? $lang : null;
+			}
+
+			// Check the user language.
+			if (!$language && $lang = JFactory::getUser()->getParam('language'))
+			{
+				$language = JLanguage::exists($lang) ? $lang : null;
+			}
+
+			// Check the browser language
+			if (!$language && (int) $this->params->get('detect_browser', 0) === 1 && $lang = JLanguageHelper::detectLanguage())
+			{
+				$language = JLanguage::exists($lang) ? $lang : null;
+			}
+
+			// Check the default language
+			if (!$language && $lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
+			{
+				$language = JLanguage::exists($lang) ? $lang : null;
+			}
+
+			// Check the config language
+			if (!$language && $lang = $this->app->config->get('language', 'en-GB'))
+			{
+				$language = JLanguage::exists($lang) ? $lang : null;
+			}
+
+			// Return the language or fallback to en-GB.
+			return !is_null($language) ? $language : 'en-GB';
+		}
+	}
+
+	/**
 	 * After initialise.
 	 *
 	 * @return  void

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -465,6 +465,11 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		// Set the request var.
 		$this->app->input->set('language', $lang_code);
+
+		// Set the user language.
+		$this->app->setUserState('language', $lang_code);
+
+		// Change the app language.
 		$this->app->set('language', $lang_code);
 		$language = JFactory::getLanguage();
 
@@ -804,27 +809,33 @@ class PlgSystemLanguageFilter extends JPlugin
 	/**
 	 * Set the language cookie
 	 *
-	 * @param   string  $lang_code  The language code for which we want to set the cookie
+	 * @param   string  $languageCode  The language code for which we want to set the cookie
 	 *
 	 * @return  void
 	 *
 	 * @since   3.4.2
 	 */
-	private function setLanguageCookie($lang_code)
+	private function setLanguageCookie($languageCode)
 	{
-		// Get the cookie lifetime we want.
-		$cookie_expire = 0;
-
-		if ($this->params->get('lang_cookie', 1) == 1)
+		// If is set to use language cookie for a year in plugin params, save the user language in a new cookie.
+		if ((int) $this->params->get('lang_cookie', 0) === 1)
 		{
-			$cookie_expire = time() + 365 * 86400;
+			// Create a cookie with one year lifetime.
+			$this->app->input->cookie->set(
+				JApplicationHelper::getHash('language'),
+				$languageCode,
+				time() + 365 * 86400,
+				$this->app->get('cookie_path', '/'),
+				$this->app->get('cookie_domain', ''),
+				$this->app->isSSLConnection(),
+				true
+			);
 		}
-
-		// Create a cookie.
-		$cookie_domain = $this->app->get('cookie_domain');
-		$cookie_path   = $this->app->get('cookie_path', '/');
-		$cookie_secure = $this->app->isSSLConnection();
-		$this->app->input->cookie->set(JApplicationHelper::getHash('language'), $lang_code, $cookie_expire, $cookie_path, $cookie_domain, $cookie_secure);
+		// If not, set the user language in the session (that is already saved in a cookie).
+		else
+		{
+			$this->app->setUserState('language', $languageCode);
+		}
 	}
 
 	/**
@@ -836,14 +847,23 @@ class PlgSystemLanguageFilter extends JPlugin
 	 */
 	private function getLanguageCookie()
 	{
-		$lang_code = $this->app->input->cookie->getString(JApplicationHelper::getHash('language'));
-
-		// Let's be sure we got a valid language code. Fallback to null.
-		if (!array_key_exists($lang_code, $this->lang_codes))
+		// Is is set to use a year language cookie in plugin params, get the user language from the cookie.
+		if ((int) $this->params->get('lang_cookie', 0) === 1)
 		{
-			$lang_code = null;
+			$languageCode = $this->app->input->cookie->get(JApplicationHelper::getHash('language'));
+		}
+		// Else get the user language from the session.
+		else
+		{
+			$languageCode = $this->app->getUserState('language', 'en-GB');
 		}
 
-		return $lang_code;
+		// Let's be sure we got a valid language code. Fallback to null.
+		if (!array_key_exists($languageCode, $this->lang_codes))
+		{
+			$languageCode = null;
+		}
+
+		return $languageCode;
 	}
 }

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -88,8 +88,6 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		parent::__construct($subject, $config);
 
-		$this->app = JFactory::getApplication();
-
 		if ($this->app->isSite())
 		{
 			// Setup language data.
@@ -111,13 +109,16 @@ class PlgSystemLanguageFilter extends JPlugin
 					unset($this->sefs[$language->sef]);
 				}
 			}
+
+			$this->app->setLanguageFilter(true);
+			$this->app->setDetectBrowser((int) $this->params->get('detect_browser', 1) === 1);
 		}
 	}
 
 	/**
 	 * On language set event.
 	 *
-	 * @return  string  App language code.
+	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -157,14 +158,13 @@ class PlgSystemLanguageFilter extends JPlugin
 				$language = JLanguage::exists($lang) ? $lang : null;
 			}
 
-			// Check the config language
+			// Check the config language or fallback to en-GB.
 			if (!$language && $lang = $this->app->config->get('language', 'en-GB'))
 			{
-				$language = JLanguage::exists($lang) ? $lang : null;
+				$language = JLanguage::exists($lang) ? $lang : 'en-GB';
 			}
 
-			// Return the language or fallback to en-GB.
-			return !is_null($language) ? $language : 'en-GB';
+			$this->app->set('language', $language);
 		}
 	}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -116,13 +116,13 @@ class PlgSystemLanguageFilter extends JPlugin
 	}
 
 	/**
-	 * On language set event.
+	 * On before language event.
 	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function onLanguageSet()
+	public function onBeforeLanguage()
 	{
 		if ($this->app->isSite())
 		{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -110,86 +110,8 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 
-			$this->checkAppLanguage();
-
 			$this->app->setLanguageFilter(true);
 			$this->app->setDetectBrowser((int) $this->params->get('detect_browser', 1) === 1);
-		}
-	}
-
-	/**
-	 * On before language event.
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected function checkAppLanguage()
-	{
-		if ($this->app->isSite())
-		{
-			$languageCode = null;
-
-			// Check the url parameters
-			if ($lang = $this->app->input->get('language', '', 'string'))
-			{
-				$languageCode = JLanguage::exists($lang) ? $lang : null;
-			}
-
-			// Check the language cookie
-			if (is_null($languageCode) && $lang = $this->app->input->cookie->get(md5($this->get('secret') . 'language'), null, 'string'))
-			{
-				$languageCode = JLanguage::exists($lang) ? $lang : null;
-			}
-
-			// Check the user language.
-			if (is_null($languageCode) && $lang = JFactory::getUser()->getParam('language'))
-			{
-				$languageCode = JLanguage::exists($lang) ? $lang : null;
-			}
-
-			// Check the browser language
-			if (is_null($languageCode) && (int) $this->params->get('detect_browser', 0) === 1 && $lang = JLanguageHelper::detectLanguage())
-			{
-				$languageCode = JLanguage::exists($lang) ? $lang : null;
-			}
-
-			// Check the default language
-			if (is_null($languageCode) && $lang = JComponentHelper::getParams('com_languages')->get('site', 'en-GB'))
-			{
-				$languageCode = JLanguage::exists($lang) ? $lang : null;
-			}
-
-			// Check the config language or fallback to en-GB.
-			if (is_null($languageCode) && $lang = $this->app->config->get('language', 'en-GB'))
-			{
-				$languageCode = JLanguage::exists($lang) ? $lang : 'en-GB';
-			}
-
-			// Get the current language.
-			$currentLanguage = JFactory::getLanguage();
-
-			if ($currentLanguage->getTag() != $languageCode)
-			{
-				// Set the app language.
-				$this->app->input->set('language', $languageCode);
-				$this->app->set('language', $languageCode);
-
-				// Build our language object
-				$newLanguage = JLanguage::getInstance($languageCode, $this->app->get('debug_lang'));
-
-				// Load the language files to the new language.
-				foreach ($currentLanguage->getPaths() as $extension => $files)
-				{
-					$newLanguage->load($extension);
-				}
-
-				// Load the language to the API
-				$this->app->loadLanguage($newLanguage);
-
-				// Register the language object with JFactory
-				JFactory::$language = $newLanguage;
-			}
 		}
 	}
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -469,22 +469,8 @@ class PlgSystemLanguageFilter extends JPlugin
 		// Set the user language.
 		$this->app->setUserState('language', $lang_code);
 
-		// Change the app language.
-		$this->app->set('language', $lang_code);
-		$language = JFactory::getLanguage();
-
-		if ($language->getTag() != $lang_code)
-		{
-			$newLang = JLanguage::getInstance($lang_code);
-
-			foreach ($language->getPaths() as $extension => $files)
-			{
-				$newLang->load($extension);
-			}
-
-			JFactory::$language = $newLang;
-			$this->app->loadLanguage($newLang);
-		}
+		// Set the app language.
+		$this->app->setLanguage($lang_code);
 
 		// Create a cookie.
 		if ($this->getLanguageCookie() != $lang_code)


### PR DESCRIPTION
### Summary of Changes

This PR aims to detach the language switcher from the `JApplicationSite` app.

To achieve this we also introduce a new method to `JApplicationCms`, the `setLanguage`method. This method allows to set a new app language while the page is being loaded.

Also we introduce a new user state `language` this user state allows to save the user langauge without the cookie (it uses the session cookie).

And many other code optimizations.
### Testing Instructions
1. Code review
2. Use latest staging with multilanguage (use several languages)
3. Apply patch
4. Test administrator language:
   - default admin language works fine
   - change default admin language in com_languages installed view works fine
   - switch admin language in com_languages installed view works fine
   - setting a user admin language in user profile/edit works fine
   - chosing a different admin language in the admin login works fine
5. Test frontend language with langauge switcher plugin DISABLED
   - default site language works fine
   - change default site language in com_languages installed view works fine
   - direct acess to language works fine `ex: index.php?language=fr-FR`
   - direct acess to language that does not exists fallback to en-GB fine `ex: index.php?language=xx-XX`
   - setting a user site language in user profile/edit works fine
6. Test frontend language with langauge switcher plugin ENABLED
   - default site language works fine
   - change default site language in com_languages installed view works fine
   - direct acess to language works fine `ex: index.php?language=fr-FR`
   - direct acess to language that does not exists fallback to en-GB fine `ex: index.php?language=xx-XX`
   - setting a user site language in user profile/edit works fine
   - check aceesing without language cookie fallback to defualt language.
7. Any other tests you could remeber
### Documentation Changes Required

None.
