### PR TITLE
[RFC] Map user groups tree on JTableUser create

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -738,45 +738,49 @@ class JAccess
 			// Registered user and guest if all groups are requested
 			else
 			{
-				$db = JFactory::getDbo();
+				// For the current user id we already have the data in JUser.
+				$user = JFactory::getUser();
 
-				// Build the database query to get the rules for the asset.
-				$query = $db->getQuery(true)
-					->select($recursive ? 'b.id' : 'a.id');
-
-				if (empty($userId))
+				if (!empty($userId) && $user->id === $userId)
 				{
-					$query->from('#__usergroups AS a')
-						->where('a.id = ' . (int) $guestUsergroup);
+					$result = $recursive ? array_keys($user->groupsMapping) : array_keys($user->groups);
 				}
+				// If not the current user we make a query.
 				else
 				{
-					$query->from('#__user_usergroup_map AS map')
-						->where('map.user_id = ' . (int) $userId)
-						->join('LEFT', '#__usergroups AS a ON a.id = map.group_id');
-				}
+					$db = JFactory::getDbo();
 
-				// If we want the rules cascading up to the global asset node we need a self-join.
-				if ($recursive)
-				{
-					$query->join('LEFT', '#__usergroups AS b ON b.lft <= a.lft AND b.rgt >= a.rgt');
-				}
+					// Build the database query to get the rules for the asset.
+					$query = $db->getQuery(true)
+						->select($recursive ? 'b.id' : 'a.id');
 
-				// Execute the query and load the rules from the result.
-				$db->setQuery($query);
-				$result = $db->loadColumn();
+					if (empty($userId))
+					{
+						$query->from('#__usergroups AS a')
+							->where('a.id = ' . (int) $guestUsergroup);
+					}
+					else
+					{
+						$query->from('#__user_usergroup_map AS map')
+							->where('map.user_id = ' . (int) $userId)
+							->join('LEFT', '#__usergroups AS a ON a.id = map.group_id');
+					}
+
+					// If we want the rules cascading up to the global asset node we need a self-join.
+					if ($recursive)
+					{
+						$query->join('LEFT', '#__usergroups AS b ON b.lft <= a.lft AND b.rgt >= a.rgt');
+					}
+
+					// Execute the query and load the rules from the result.
+					$db->setQuery($query);
+					$result = $db->loadColumn();
+				}
 
 				// Clean up any NULL or duplicate values, just in case
 				$result = ArrayHelper::toInteger($result);
 
-				if (empty($result))
-				{
-					$result = array('1');
-				}
-				else
-				{
-					$result = array_unique($result);
-				}
+				$result = empty($result) ? array('1') : array_unique($result);
 			}
 
 			self::$groupsByUser[$storeId] = $result;

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -743,7 +743,22 @@ class JAccess
 
 				if (!empty($userId) && $user->id === $userId)
 				{
-					$result = $recursive ? array_keys($user->groupsMapping) : array_keys($user->groups);
+					if (!$recursive)
+					{
+						$result = array_keys($user->groups);
+					}
+					else
+					{
+						$result = array();
+
+						foreach($user->childGroups as $userGroup => $childGroups)
+						{
+							foreach($childGroups as $key => $groupId)
+							{
+								$result[] = $groupId;
+							}
+						}
+					}
 				}
 				// If not the current user we make a query.
 				else

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -28,12 +28,12 @@ class JTableUser extends JTable
 	public $groups;
 
 	/**
-	 * Associative array of group ids => group ids for the user
+	 * Associative array of the child group ids
 	 *
 	 * @var    array
 	 * @since  11.1
 	 */
-	public $groupsMapping;
+	public $childGroups;
 
 	/**
 	 * Constructor
@@ -123,13 +123,13 @@ class JTableUser extends JTable
 			// Add the groups to the user data.
 			$groups = $this->_db->loadObjectList();
 
-			$this->groups        = array();
-			$this->groupsMapping = array();
+			$this->groups      = array();
+			$this->childGroups = array();
 
 			foreach($groups as $key => $group)
 			{
-				$this->groups[$group->id]              = $group->id;
-				$this->groupsMapping[$group->child_id] = $group->id;
+				$this->groups[$group->id]        = $group->id;
+				$this->childGroups[$group->id][] = $group->child_id;
 			}
 		}
 

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -43,28 +43,11 @@ abstract class JUserHelper
 			// Add the group data to the user object.
 			$user->groups[$groupId] = $groupId;
 
-			// @todo: add the child groups
-			$user->childGroups[$groupId] = array();
-
 			// Store the user object.
 			$user->save();
-		}
 
-		// Set the group data for any preloaded user objects.
-		$temp              = JUser::getInstance((int) $userId);
-		$temp->groups      = $user->groups;
-		$temp->childGroups = $user->childGroups;
-
-		if (JFactory::getSession()->getId())
-		{
-			// Set the group data for the user object in the session.
-			$temp = JFactory::getUser();
-
-			if ($temp->id == $userId)
-			{
-				$temp->groups      = $user->groups;
-				$temp->childGroups = $user->childGroups;
-			}
+			// Preload the user groups.
+			$user->preloadUserGroups((int) $userId);
 		}
 
 		return true;
@@ -126,24 +109,12 @@ abstract class JUserHelper
 		{
 			// Remove the user from the group.
 			unset($user->groups[$key]);
-			unset($user->childGroups[$key]);
 
 			// Store the user object.
 			$user->save();
-		}
 
-		// Set the group data for any preloaded user objects.
-		$temp = JFactory::getUser((int) $userId);
-		$temp->groups      = $user->groups;
-		$temp->childGroups = $user->childGroups;
-
-		// Set the group data for the user object in the session.
-		$temp = JFactory::getUser();
-
-		if ($temp->id == $userId)
-		{
-			$temp->groups      = $user->groups;
-			$temp->childGroups = $user->childGroups;
+			// Preload the user groups.
+			$user->preloadUserGroups((int) $userId);
 		}
 
 		return true;
@@ -165,31 +136,13 @@ abstract class JUserHelper
 		$user = JUser::getInstance((int) $userId);
 
 		// Set the group ids.
-		$groups = ArrayHelper::toInteger($groups);
-		$user->groups = $groups;
-
-		// @todo: add the child groups
-		$user->childGroups = $groups;
+		$user->groups = ArrayHelper::toInteger($groups);
 
 		// Store the user object.
 		$user->save();
 
-		if (session_id())
-		{
-			// Set the group data for any preloaded user objects.
-			$temp = JFactory::getUser((int) $userId);
-			$temp->groups      = $user->groups;
-			$temp->childGroups = $user->childGroups;
-
-			// Set the group data for the user object in the session.
-			$temp = JFactory::getUser();
-
-			if ($temp->id == $userId)
-			{
-				$temp->groups      = $user->groups;
-				$temp->childGroups = $user->childGroups;
-			}
-		}
+		// Preload the user groups.
+		$user->preloadUserGroups((int) $userId);
 
 		return true;
 	}

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -132,12 +132,12 @@ class JUser extends JObject
 	public $groups = array();
 
 	/**
-	 * Associative array of user groups mapping
+	 * Associative array of the child group ids
 	 *
 	 * @var    array
 	 * @since  11.1
 	 */
-	public $groupsMapping = array();
+	public $childGroups = array();
 
 	/**
 	 * Guest status

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -132,6 +132,14 @@ class JUser extends JObject
 	public $groups = array();
 
 	/**
+	 * Associative array of user groups mapping
+	 *
+	 * @var    array
+	 * @since  11.1
+	 */
+	public $groupsMapping = array();
+
+	/**
 	 * Guest status
 	 *
 	 * @var    boolean


### PR DESCRIPTION
### Summary of Changes

This PR aims to remove one db query that happens everytime a user is logged. The JAccess user groups mapping.
This is checked on every page when a user is logged.

It does so by loading the user groups mapping in the same query (which already exists) that we get the groups for the current user. 
#### Before patch (two queries)

![image](https://cloud.githubusercontent.com/assets/9630530/18673244/fd1fdf54-7f42-11e6-822f-337097637d5a.png)
![image](https://cloud.githubusercontent.com/assets/9630530/18673255/07ad7d5a-7f43-11e6-851e-8183ae97e618.png)
#### After patch (only one query)

![image](https://cloud.githubusercontent.com/assets/9630530/18673199/d5d337c0-7f42-11e6-9231-5ecfd40961b5.png)

Note: Ignore the duplicate queries (it's added by the debug system plugin for showing the session data).
### Testing Instructions
1. code review.
2. .... later.
### Documentation Changes Required

None.
