### PR TITLE
[RFC] Allow to hardcode table columns for performance

### DIFF
--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -49,6 +49,23 @@ class JTableAsset extends JTableNested
 	public $rules = null;
 
 	/**
+	 * Array with table columns names hardcoded, for performance.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $columns = array(
+		'id'        => null,
+		'parent_id' => null,
+		'lft'       => null,
+		'rgt'       => null,
+		'level'     => null,
+		'name'      => null,
+		'title'     => null,
+		'rules'     => null,
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  Database driver object.

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -49,23 +49,6 @@ class JTableAsset extends JTableNested
 	public $rules = null;
 
 	/**
-	 * Array with table columns names hardcoded, for performance.
-	 *
-	 * @var    array
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected $columns = array(
-		'id'        => null,
-		'parent_id' => null,
-		'lft'       => null,
-		'rgt'       => null,
-		'level'     => null,
-		'name'      => null,
-		'title'     => null,
-		'rules'     => null,
-	);
-
-	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  Database driver object.
@@ -74,6 +57,18 @@ class JTableAsset extends JTableNested
 	 */
 	public function __construct($db)
 	{
+		// Hardcode the asset table columns for performance.
+		$this->columns = array(
+			'id'        => (object) array('Field' => 'id', 'Default' => ''),
+			'parent_id' => (object) array('Field' => 'parent_id', 'Default' => 0),
+			'lft'       => (object) array('Field' => 'lft', 'Default' => 0),
+			'rgt'       => (object) array('Field' => 'rgt', 'Default' => 0),
+			'level'     => (object) array('Field' => 'level', 'Default' => ''),
+			'name'      => (object) array('Field' => 'name', 'Default' => ''),
+			'title'     => (object) array('Field' => 'title', 'Default' => ''),
+			'rules'     => (object) array('Field' => 'rules', 'Default' => ''),
+		);
+
 		parent::__construct('#__assets', 'id', $db);
 	}
 

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -117,6 +117,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	protected $_jsonEncode = array();
 
 	/**
+	 * Array with table columns names hardcoded, for performance.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $columns = null;
+
+	/**
 	 * Object constructor to set table and key fields.  In most cases this will
 	 * be overridden by child classes to explicitly set the table and key fields
 	 * for a particular database table.
@@ -225,24 +233,34 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	/**
 	 * Get the columns from database table.
 	 *
+	 * @param   bool  $reload  flag to reload cache
+	 *
 	 * @return  mixed  An array of the field names, or false if an error occurs.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
-	public function getFields()
+	public function getFields($reload = false)
 	{
 		static $cache = null;
 
-		if ($cache === null)
+		if ($cache === null || $reload)
 		{
-			// Lookup the fields for this table only once.
-			$name   = $this->_tbl;
-			$fields = $this->_db->getTableColumns($name, false);
-
-			if (empty($fields))
+			// If the columns values are hardcoded, for performance we use them.
+			if (!is_null($this->columns) && !$reload)
 			{
-				throw new UnexpectedValueException(sprintf('No columns found for %s table', $name));
+				$fields = $this->columns;
+			}
+			// Lookup the fields for this table only once.
+			else
+			{
+				$name   = $this->_tbl;
+				$fields = $this->_db->getTableColumns($name, false);
+
+				if (empty($fields))
+				{
+					throw new UnexpectedValueException(sprintf('No columns found for %s table', $name));
+				}
 			}
 
 			$cache = $fields;


### PR DESCRIPTION
### Summary of Changes

Everytime Joomla creates a JTable object it makes an expensive query to get the table columns.
This seams to happen everytime the page is loaded.
This is, IMHO, a disavantage when using JTable, because in the first time you get this query.

However, joomla core table columns change very little over time.
So this PR proposes to add a new property to JTable `columns` that can be used to hardcode the table columns for performance in the cases that justifies.

As a PoC i hardcoded the JTableAsset columns (`#__assets`).
If there is interrest in this i can make the same for other JTableXxxx.
### Testing Instructions
- Code review
- Use 3.7.x branch
- Turn on system debug and system debug plugin
- Refresh the page you will see several queries like this one
  ![image](https://cloud.githubusercontent.com/assets/9630530/18689664/3c67686e-7f82-11e6-99cb-183234f40f61.png)
- Apply this patch and refresh the page
- Check that this particular query above is gone and everything still work.
### Documentation Changes Required

None.
