### PR TITLE
poc bc access

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -414,7 +414,7 @@ class JAccess
 	 * e.g. it will get 'com_content', but not 'com_content.article.1' or
 	 * any more specific asset type rules.
 	 *
-	 * @return   array Array of component names that were preloaded.
+	 * @return   array  Array of component names that were preloaded.
 	 *
 	 * @since    1.6
 	 */
@@ -505,7 +505,7 @@ class JAccess
 
 		!JDEBUG ?: JProfiler::getInstance('Application')->mark('After JAccess::preload (all components)');
 
-		return true;
+		return $components;
 	}
 
 	/**

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -52,6 +52,16 @@ class JAccess
 	 */
 	protected static $assetPermissionsById = array();
 
+ 	/**
+	 * Array of permissions for an asset type
+	 * (Array Key = Asset Name)
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated  __DEPLOY_VERSION__  No replacement. Will be removed in 4.0.
+	 */
+	protected static $assetPermissionsByName = array();
+
 	/**
 	 * Array of permissions for an asset type
 	 * (Array Key = Asset Name)
@@ -59,7 +69,16 @@ class JAccess
 	 * @var    array
 	 * @since  11.1
 	 */
-	protected static $assetPermissionsByName = array();
+	protected static $assetIdByName = array();
+
+ 	/**
+	 * Array of the permission parent ID mappings
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated  __DEPLOY_VERSION__  No replacement. Will be removed in 4.0.
+	 */
+	protected static $assetPermissionsParentIdMapping = array();
 
 	/**
 	 * Array of asset types that have been preloaded
@@ -110,6 +129,14 @@ class JAccess
 	protected static $componentsPreloaded = false;
 
 	/**
+	 * Array with the root Asset (id, name).
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $rootAsset = array();
+
+	/**
 	 * Method for clearing static caches.
 	 *
 	 * @return  void
@@ -118,16 +145,22 @@ class JAccess
 	 */
 	public static function clearStatics()
 	{
-		self::$componentsPreloaded    = false;
-		self::$viewLevels             = array();
-		self::$assetPermissionsById   = array();
-		self::$assetPermissionsByName = array();
-		self::$preloadedAssetTypes    = array();
-		self::$identities             = array();
-		self::$assetRules             = array();
-		self::$userGroups             = array();
-		self::$userGroupPaths         = array();
-		self::$groupsByUser           = array();
+		self::$viewLevels           = array();
+		self::$assetRules           = array();
+		self::$assetRulesIdentities = array();
+		self::$assetPermissionsById = array();
+		self::$assetIdByName        = array();
+		self::$preloadedAssetTypes  = array();
+		self::$identities           = array();
+		self::$userGroups           = array();
+		self::$userGroupPaths       = array();
+		self::$groupsByUser         = array();
+		self::$componentsPreloaded  = false;
+		self::$rootAsset            = array();
+
+		// The following properties are deprecated since __DEPLOY_VERSION__ and will be removed in 4.0.
+		self::$assetPermissionsParentIdMapping = array();
+		self::$assetPermissionsByName          = array();
 	}
 
 	/**
@@ -149,23 +182,31 @@ class JAccess
 		$action = strtolower(preg_replace('#[\s\-]+#', '.', trim($action)));
 		$asset  = strtolower(preg_replace('#[\s\-]+#', '.', trim($asset)));
 
+		if ($preload)
+		{
+			self::preload('components');
+		}
+
 		// Default to the root asset node.
 		if (empty($asset))
 		{
-			$db = JFactory::getDbo();
-			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
-			$asset  = $assets->getRootId();
+			// Auto preloads assets for the asset type.
+			if ($preload)
+			{
+				$asset = self::$rootAsset['name'];
+			}
+			// No preload. Get from table.
+			else
+			{
+				$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => JFactory::getDbo()));
+				$asset  = $assets->getRootId();
+			}
 		}
 
-		// Auto preloads assets for the asset type:
-		if (!is_numeric($asset) && $preload)
+		// Auto preloads assets for the asset type.
+		if ($preload)
 		{
-			$assetType = self::getAssetType($asset);
-
-			if (!isset(self::$preloadedAssetTypes[$assetType]))
-			{
-				self::preload($assetType);
-			}
+			self::preload($asset);
 		}
 
 		// Get the rules for the asset recursively to root if not already retrieved.
@@ -190,37 +231,25 @@ class JAccess
 	 * @param   string|array  $assetTypes  e.g. 'com_content.article'
 	 * @param   boolean       $reload      Set to true to reload from database.
 	 *
-	 * @return   boolean True on success.
+	 * @return  boolean True on success.
 	 *
-	 * @since    1.6
+	 * @since   1.6
+	 * @note    This method will return void in 4.0.
 	 */
 	public static function preload($assetTypes = 'components', $reload = false)
 	{
 		// Check for default case:
 		$isDefault = is_string($assetTypes) && in_array($assetTypes, array('components', 'component'));
 
-		// Preload the rules for all of the components:
-		if ($isDefault && !self::$componentsPreloaded)
-		{
-			// Mark in the profiler.
-			!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::preload (all components)');
-
-			self::preloadComponents();
-			self::$componentsPreloaded = true;
-
-			// Mark in the profiler.
-			!JDEBUG ?: JProfiler::getInstance('Application')->mark('After JAccess::preload (all components)');
-		}
-
-		// Quick short circuit for default case
+		// Preload the rules for all of the components.
 		if ($isDefault)
 		{
+			self::preloadComponents();
+
 			return true;
 		}
 
-		// If we get to this point, this is a regular asset type
-		// and we'll proceed with the preloading process.
-
+		// If we get to this point, this is a regular asset type and we'll proceed with the preloading process.
 		if (!is_array($assetTypes))
 		{
 			$assetTypes = (array) $assetTypes;
@@ -228,15 +257,7 @@ class JAccess
 
 		foreach ($assetTypes as $assetType)
 		{
-			if (!isset(self::$preloadedAssetTypes[$assetType]) || $reload)
-			{
-				!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::preload (' . $assetType . ')');
-
-				self::preloadPermissions($assetType);
-				self::$preloadedAssetTypes[$assetType] = true;
-
-				!JDEBUG ?: JProfiler::getInstance('Application')->mark('After JAccess::preload (' . $assetType . ')');
-			}
+			self::preloadPermissions($assetType, $reload);
 		}
 
 		return true;
@@ -249,9 +270,9 @@ class JAccess
 	 * @param   string      $extensionName  e.g. 'com_content.article'
 	 * @param   string|int  $assetId        numeric Asset ID
 	 *
-	 * @return   array  List of Ancestor IDs (includes original $assetId)
+	 * @return  array  List of Ancestor IDs (includes original $assetId)
 	 *
-	 * @since    1.6
+	 * @since   1.6
 	 */
 	protected static function getAssetAncestors($extensionName, $assetId)
 	{
@@ -287,44 +308,101 @@ class JAccess
 	}
 
 	/**
+	 * Method to retrieve the list of Asset IDs and their Parent Asset IDs
+	 * and store them for later usage in getAssetRules().
+	 *
+	 * @param   string  $assetType  e.g. 'com_content.article'
+	 *
+	 * @return   array  List of Asset IDs (includes Parent Asset ID Info)
+	 *
+	 * @since    1.6
+	 * @deprecated  __DEPLOY_VERSION__  No replacement. Will be removed in 4.0.
+	 */
+	protected static function &preloadPermissionsParentIdMapping($assetType)
+	{
+		// Get the extension name from the $assetType provided
+		$extensionName = self::getExtensionNameFromAsset($assetType);
+
+		if (!isset(self::$assetPermissionsParentIdMapping[$extensionName]))
+		{
+			// Get the database connection object.
+			$db = JFactory::getDbo();
+
+			// Get a fresh query object:
+			$query    = $db->getQuery(true);
+
+			// Build the database query:
+			$query->select('a.id, a.parent_id');
+			$query->from('#__assets AS a');
+			$query->where('(a.name LIKE ' . $db->quote($extensionName . '.%') . ' OR a.name = ' . $db->quote($extensionName) . ' OR a.id = 1)');
+
+			// Get the Name Permission Map List
+			$db->setQuery($query);
+			$parentIdMapping = $db->loadObjectList('id');
+
+			self::$assetPermissionsParentIdMapping[$extensionName] = &$parentIdMapping;
+		}
+
+		return self::$assetPermissionsParentIdMapping[$extensionName];
+	}
+
+	/**
 	 * Method to retrieve the Asset Rule strings for this particular
 	 * Asset Type and stores them for later usage in getAssetRules().
 	 * Stores 2 arrays: one where the list has the Asset ID as the key
 	 * and a second one where the Asset Name is the key.
 	 *
-	 * @param   string  $assetType  e.g. 'com_content.article'
+	 * @param   string   $assetType  e.g. 'com_content.article'
+	 * @param   boolean  $reload     Reload the permissions.
 	 *
-	 * @return   bool  True
+	 * @return  bool  True
 	 *
-	 * @since    1.6
+	 * @since   1.6
+	 * @note    This function will return void in 4.0.
 	 */
-	protected static function preloadPermissions($assetType)
+	protected static function preloadPermissions($assetType, $reload = false)
 	{
 		// Get the extension name from the $assetType provided
 		$extensionName = self::getExtensionNameFromAsset($assetType);
 
-		// Get the database connection object.
-		$db = JFactory::getDbo();
+		// If asset is not the root or a component (already preloaded), make sure the all the component assets are preloaded.
+		if ((isset(self::$assetPermissionsById[$assetType]) || isset(self::$preloadedAssetTypes[$extensionName])) && !$reload)
+		{
+			return;
+		}
 
-		$parents = implode(',', $db->q(array($extensionName, 'root.1')));
+		!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::preloadPermissions (' . $extensionName . ')');
+
+		// Get the database connection object.
+		$db         = JFactory::getDbo();
+		$extraQuery = $db->qn('name') . ' IN (' . implode(',', $db->q(array($extensionName))) . ') OR ' . $db->qn('parent_id') . ' = 0';
 
 		// Get a fresh query object:
 		$query = $db->getQuery(true)
 			->select($db->qn(array('id', 'name', 'rules', 'parent_id')))
 			->from($db->qn('#__assets'))
-			->where($db->qn('name') . ' LIKE ' . $db->q($extensionName . '.%') . ' OR ' . $db->qn('name') . ' IN (' . $parents . ')');
+			->where($db->qn('name') . ' LIKE ' . $db->q($extensionName . '.%') . ' OR ' . $extraQuery);
 
 		// Get the Name Permission Map List
 		$assets = $db->setQuery($query)->loadObjectList();
 
-		self::$assetPermissionsById[$extensionName]   = array();
+		self::$assetPermissionsById[$extensionName] = array();
+
+		// B/C Populate the method property. This property is deprecated since __DEPLOY_VERSION__ and will be removed in 4.0.
 		self::$assetPermissionsByName[$extensionName] = array();
 
 		foreach ($assets as $asset)
 		{
-			self::$assetPermissionsById[$extensionName][$asset->id]     = $asset;
+			self::$assetPermissionsById[$extensionName][$asset->id] = $asset;
+			self::$assetIdByName[$asset->name]                      = $asset->id;
+
+			// B/C Populate the method property. This property is deprecated since __DEPLOY_VERSION__ and will be removed in 4.0.
 			self::$assetPermissionsByName[$extensionName][$asset->name] = $asset;
 		}
+
+		self::$preloadedAssetTypes[$extensionName] = true;
+
+		!JDEBUG ?: JProfiler::getInstance('Application')->mark('After JAccess::preloadPermissions (' . $extensionName . ')');
 
 		return true;
 	}
@@ -342,6 +420,14 @@ class JAccess
 	 */
 	protected static function preloadComponents()
 	{
+		// If the components already been preloaded do nothing.
+		if (self::$componentsPreloaded)
+		{
+			return;
+		}
+
+		!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::preload (all components)');
+
 		// Add root to asset names list.
 		$components = array();
 
@@ -361,42 +447,65 @@ class JAccess
 		$query = $db->getQuery(true)
 			->select($db->qn(array('id', 'name', 'rules', 'parent_id')))
 			->from($db->qn('#__assets'))
-			->where($db->qn('name') . ' IN (' . implode(',', $db->quote($components)) . ', ' . $db->quote('root.1') . ')');
+			->where($db->qn('name') . ' IN (' . implode(',', $db->quote($components)) . ') OR ' . $db->qn('parent_id') . ' = 0');
 
 		// Get the Name Permission Map List
 		$assets = $db->setQuery($query)->loadObjectList('name');
 
 		// Add the root asset as parent of all components.
 		$assetsTree = array();
-		$rootName   = 'root.1';
 
+		// First find the root asset
 		foreach ($assets as $extensionName => $asset)
 		{
-			$assetsTree[$extensionName][] = $assets[$rootName];
-
-			if ($extensionName !== $rootName)
+			// First add the root asset. If not the root asset inself.
+			if ((int) $asset->parent_id !== 0)
 			{
-				$assetsTree[$extensionName][] = $assets[$extensionName];
+				continue;
 			}
+
+			self::$rootAsset = array('id' => $asset->id, 'name' => $asset->name);
 		}
 
-		// Save the permissions for the components asset.
+		// Now create the components asset tree.
+		foreach ($assets as $extensionName => $asset)
+		{
+			// First add the root asset. If not the root asset inself.
+			if ((int) $asset->parent_id !== 0)
+			{
+				$assetsTree[$extensionName][] = $assets[self::$rootAsset['name']];
+			}
+
+			// Now we add the component asset.
+			$assetsTree[$extensionName][] = $assets[$extensionName];
+		}
+
+		// Store the permissions for the components asset for faster access.
 		foreach ($assetsTree as $extensionName => $assets)
 		{
 			if (!isset(self::$preloadedAssetTypes[$extensionName]))
 			{
-				self::$assetPermissionsById[$extensionName]   = array();
+				self::$assetPermissionsById[$extensionName] = array();
+
+				// B/C Populate the method property. This property is deprecated since __DEPLOY_VERSION__ and will be removed in 4.0.
 				self::$assetPermissionsByName[$extensionName] = array();
 
 				foreach ($assets as $asset)
 				{
-					self::$assetPermissionsById[$extensionName][$asset->id]     = $asset;
+					self::$assetPermissionsById[$extensionName][$asset->id] = $asset;
+					self::$assetIdByName[$asset->name] = $asset->id;
+
+					// B/C Populate the method property. This property is deprecated since __DEPLOY_VERSION__ and will be removed in 4.0.
 					self::$assetPermissionsByName[$extensionName][$asset->name] = $asset;
 				}
-
-				self::$preloadedAssetTypes[$extensionName] = true;
 			}
 		}
+
+		self::$componentsPreloaded = true;
+
+		!JDEBUG ?: JProfiler::getInstance('Application')->mark('After JAccess::preload (all components)');
+
+		return true;
 	}
 
 	/**
@@ -405,12 +514,13 @@ class JAccess
 	 * @param   integer  $groupId  The path to the group for which to check authorisation.
 	 * @param   string   $action   The name of the action to authorise.
 	 * @param   mixed    $asset    Integer asset id or the name of the asset as a string.  Defaults to the global asset node.
+	 * @param   boolean  $preload  Indicates whether preloading should be used
 	 *
 	 * @return  boolean  True if authorised.
 	 *
 	 * @since   11.1
 	 */
-	public static function checkGroup($groupId, $action, $asset = null)
+	public static function checkGroup($groupId, $action, $asset = null, $preload = true)
 	{
 		// Sanitize inputs.
 		$groupId = (int) $groupId;
@@ -420,12 +530,25 @@ class JAccess
 		// Get group path for group
 		$groupPath = self::getGroupPath($groupId);
 
+		if ($preload)
+		{
+			self::preload('components');
+		}
+
 		// Default to the root asset node.
 		if (empty($asset))
 		{
-			$db = JFactory::getDbo();
-			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
-			$asset = $assets->getRootId();
+			// Auto preloads assets for the asset type.
+			if ($preload && isset(self::$rootAsset['name']))
+			{
+				$asset = self::$rootAsset['name'];
+			}
+			// No preload. Get from table.
+			else
+			{
+				$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => JFactory::getDbo()));
+				$asset  = $assets->getRootId();
+			}
 		}
 
 		// Get the rules for the asset recursively to root if not already retrieved.
@@ -465,7 +588,7 @@ class JAccess
 	 * only the rules explicitly set for the asset or the summation of all inherited rules from
 	 * parent assets and explicit rules.
 	 *
-	 * @param   mixed    $asset                 Integer asset id or the name of the asset as a string.
+	 * @param   mixed    $assetKey              Integer asset id or the name of the asset as a string.
 	 * @param   boolean  $recursive             True to return the rules object with inherited rules.
 	 * @param   boolean  $recursiveParentAsset  True to calculate the rule also based on inherited component/extension rules.
 	 *
@@ -473,70 +596,90 @@ class JAccess
 	 *
 	 * @since   11.1
 	 */
-	public static function getAssetRules($asset, $recursive = false, $recursiveParentAsset = true)
+	public static function getAssetRules($assetKey, $recursive = false, $recursiveParentAsset = true)
 	{
-		$method = '';
-
-		// Get instance of the Profiler:
-		$extensionName = self::getExtensionNameFromAsset($asset);
-		$assetType     = self::getAssetType($asset);
-
 		// Make sure the components assets are preloaded.
-		if (!self::$componentsPreloaded)
-		{
-			self::preload('components');
-		}
+		self::preload('components');
 
-		!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::getAssetRules (' . $asset . ')');
+		$method        = '';
+		$assetName     = self::getAssetName($assetKey);
+		$extensionName = self::getExtensionNameFromAsset($assetName);
 
-		// Almost all calls should have recursive set to true so we'll get to take advantage of preloading.
-		if ($recursive && $recursiveParentAsset && (isset(self::$preloadedAssetTypes[$assetType]) || isset(self::$preloadedAssetTypes[$extensionName])))
+		// Make sure the all the component assets are preloaded if needed.
+		self::preload($assetName);
+
+		// Get the asset id.
+		$assetId = self::getAssetId($assetKey);
+
+		!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::getAssetRules (id:' . $assetId . ' name:' . $assetName . ')');
+
+		// If asset does not exist fallback to extension asset, then root asset, then empty rule.
+		if (!$assetId)
 		{
-			// The asset type (ex: com_modules.module) as been preloaded, but the asset does not exist  (ex: com_modules.module.37).
-			// In this case we fallback to extension name asset.
-			if (!isset(self::$assetPermissionsByName[$extensionName][$asset]))
+			if ($assetName !== $extensionName)
 			{
-				self::$assetPermissionsByName[$extensionName][$asset] = self::$assetPermissionsByName[$extensionName][$extensionName];
+				JLog::add('No asset found for ' . $assetName . ', falling back to ' . $extensionName, JLog::WARNING, 'assets');
+
+				return self::getAssetRules($extensionName, $recursive, $recursiveParentAsset);
 			}
 
-			$assetId = self::$assetPermissionsByName[$extensionName][$asset]->id;
+			if (isset(self::$rootAsset['name']) && $assetName !== self::$rootAsset['name'])
+			{
+				JLog::add('No asset found for ' . $assetName . ', falling back to ' . self::$rootAsset['name'], JLog::WARNING, 'assets');
 
-			$ancestors = array_reverse(self::getAssetAncestors($extensionName, $assetId));
+				return self::getAssetRules(self::$rootAsset['name'], $recursive, $recursiveParentAsset);
+			}
 
-			// Collects permissions for each $asset
+			JLog::add('No asset found for ' . $assetName . ', falling back to empty asset', JLog::WARNING, 'assets');
+
+			return new JAccessRules;
+		}
+
+		// Almost all calls can take advantage of preloading.
+		if (isset(self::$assetPermissionsById[$extensionName]) && isset(self::$assetPermissionsById[$extensionName][$assetId]))
+		{
+			// Collects permissions for each asset
 			$collected = array();
 
-			foreach ($ancestors as $id)
+			// If not in any recursive mode. We only want the asset rules.
+			if (!$recursive && !$recursiveParentAsset)
 			{
-				$collected[] = self::$assetPermissionsById[$extensionName][$id]->rules;
+				$collected = array(self::$assetPermissionsById[$extensionName][$assetId]->rules);
+			}
+			// If there is any type of recursive mode.
+			else
+			{
+				$ancestors = array_reverse(self::getAssetAncestors($extensionName, $assetId));
+
+				foreach ($ancestors as $id)
+				{
+					// If full recursive mode, but not recursive parent mode, do not add the extension asset rules.
+					if ($recursive && !$recursiveParentAsset && self::$assetPermissionsById[$extensionName][$id]->name === $extensionName)
+					{
+						continue;
+					}
+
+					// If not full recursive mode, but recursive parent mode, do not add other recursion rules.
+					if (!$recursive && $recursiveParentAsset && self::$assetPermissionsById[$extensionName][$id]->name !== $extensionName
+						&& self::$assetPermissionsById[$extensionName][$id]->id !== $assetId)
+					{
+						continue;
+					}
+
+					$collected[] = self::$assetPermissionsById[$extensionName][$id]->rules;
+				}
 			}
 
-			/**
-			* Hashing the collected rules allows us to store
-			* only one instance of the JAccessRules object for
-			* Assets that have the same exact permissions...
-			* it's a great way to save some memory.
-			*/
-			$hash = md5(implode(',', $collected));
-
-			if (!isset(self::$assetRulesIdentities[$hash]))
-			{
-				$rules = new JAccessRules;
-				$rules->mergeCollection($collected);
-
-				self::$assetRulesIdentities[$hash] = $rules;
-			}
-
-			$rules = self::$assetRulesIdentities[$hash];
+			$rules = self::storeRecursiveAssetRules($collected);
 		}
+		// Old method, slower. direct bd query for each. Only used in rare cases.
 		else
 		{
 			$method = ' <strong>Slower</strong>, no preloading, method used.';
 
-			if ($asset === "1")
+			// There's no need to process it with the recursive method for the Root Asset ID.
+			if ($assetId === 1)
 			{
-				// There's no need to process it with the
-				// recursive method for the Root Asset ID.
 				$recursive = false;
 			}
 
@@ -545,65 +688,61 @@ class JAccess
 
 			// Build the database query to get the rules for the asset.
 			$query = $db->getQuery(true)
-				->select($recursive ? 'DISTINCT(b.rules)' : 'a.rules')
-				->from('#__assets AS a');
+				->select(($recursive ? 'DISTINCT(b.rules)' : 'a.rules'), 'rules')
+				->select($db->qn(($recursive ? array('b.id', 'b.name', 'b.parent_id') : array('a.id', 'a.name', 'a.parent_id'))))
+				->from($db->qn('#__assets', 'a'));
 
-			$extensionString = '';
+			$extensionString = $recursiveParentAsset && $extensionName !== $assetKey ? ' OR a.name = ' . $db->quote($extensionName) : '';
+			$recursiveString = $recursive ? ' OR a.parent_id=0' : '';
 
-			if ($recursiveParentAsset && ($extensionName !== $asset || is_numeric($asset)))
-			{
-				$extensionString = ' OR a.name = ' . $db->quote($extensionName);
-			}
-
-			$recursiveString = '';
-
-			if ($recursive)
-			{
-				$recursiveString = ' OR a.parent_id=0';
-			}
-
-			// If the asset identifier is numeric assume it is a primary key, else lookup by name.
-			if (is_numeric($asset))
-			{
-				$query->where('(a.id = ' . (int) $asset . $extensionString . $recursiveString . ')');
-			}
-			else
-			{
-				$query->where('(a.name = ' . $db->quote($asset) . $extensionString . $recursiveString . ')');
-			}
+			$query->where('(a.id = ' . $assetId . $extensionString . $recursiveString . ')');
 
 			// If we want the rules cascading up to the global asset node we need a self-join.
 			if ($recursive)
 			{
-				$query->join('LEFT', '#__assets AS b ON b.lft <= a.lft AND b.rgt >= a.rgt')
-					->order('b.lft');
+				$query->join('LEFT', $db->qn('#__assets', 'b') . ' ON b.lft <= a.lft AND b.rgt >= a.rgt')
+					->order($db->qn('b.lft'));
 			}
 
 			// Execute the query and load the rules from the result.
-			$db->setQuery($query);
-			$result = $db->loadColumn();
+			$result = $db->setQuery($query)->loadObjectList();
 
-			// Get the root even if the asset is not found and in recursive mode
+			// Get the parent asset is not found and in recursive mode
 			if (empty($result))
 			{
 				$db = JFactory::getDbo();
 				$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
 				$rootId = $assets->getRootId();
 				$query->clear()
-					->select('rules')
-					->from('#__assets')
-					->where('id = ' . $db->quote($rootId));
-				$db->setQuery($query);
-				$result = $db->loadResult();
-				$result = array($result);
+					->select($db->qn(array('id', 'name', 'parent_id', 'rules')))
+					->from($db->qn('#__assets'))
+					->where($db->qn('id') . ' = ' . $db->q($rootId));
+
+				$result = $db->setQuery($query)->loadObjectList();
 			}
 
-			// Instantiate and return the JAccessRules object for the asset rules.
-			$rules = new JAccessRules;
-			$rules->mergeCollection($result);
+			// Collects permissions for each $asset
+			$collected = array();
+
+			foreach ($result as $asset)
+			{
+				// Add the asset to asset cache if needed.
+				if (!isset(self::$assetPermissionsById[$extensionName][$asset->id]))
+				{
+					self::$assetPermissionsById[$extensionName][$asset->id] = $asset;
+					self::$assetIdByName[$asset->name]                      = $asset->id;
+
+					// B/C Populate the method property. This property is deprecated since __DEPLOY_VERSION__ and will be removed in 4.0.
+					self::$assetPermissionsByName[$extensionName][$asset->name] = $asset;
+				}
+
+				$collected[] = $asset->rules;
+			}
+
+			$rules = self::storeRecursiveAssetRules($collected);
 		}
 
-		!JDEBUG ?: JProfiler::getInstance('Application')->mark('After JAccess::getAssetRules (' . $asset . ')' . $method);
+		!JDEBUG ?: JProfiler::getInstance('Application')->mark('After JAccess::getAssetRules (id:' . $assetId . ' name:' . $assetName . ')' . $method);
 
 		return $rules;
 	}
@@ -611,40 +750,141 @@ class JAccess
 	/**
 	 * Method to get the extension name from the asset name.
 	 *
-	 * @param   string  $asset  Asset Name
+	 * @param   array  $collectedRules  Array of asset rules.
+	 *
+	 * @return  string  The recursive asset rules.
+	 *
+	 * @since    __DEPLOY_VERSION__
+	 */
+	protected static function storeRecursiveAssetRules($collectedRules)
+	{
+		/**
+		* Hashing the collected rules allows us to store
+		* only one instance of the JAccessRules object for
+		* Assets that have the same exact permissions...
+		* it's a great way to save some memory.
+		*/
+		$hash = md5(implode(',', $collectedRules));
+
+		if (!isset(self::$assetRulesIdentities[$hash]))
+		{
+			$rules = new JAccessRules;
+			$rules->mergeCollection($collectedRules);
+
+			self::$assetRulesIdentities[$hash] = $rules;
+		}
+
+		return self::$assetRulesIdentities[$hash];
+	}
+
+	/**
+	 * Method to get the asset id form the asset key (id or name), using preload if already preloaded.
+	 *
+	 * @param   string  $assetKey  Asset Key (id or name).
+	 *
+	 * @return  string  Asset id.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getAssetId($assetKey)
+	{
+		static $loaded = array();
+
+		// If the asset is already an id return it.
+		if (is_numeric($assetKey))
+		{
+			return (int) $assetKey;
+		}
+
+		if (!isset($loaded[$assetKey]))
+		{
+			// If we already have the asset name stored in preloading, example, a component, no need to fetch it from table.
+			if (isset(self::$assetIdByName[$assetKey]))
+			{
+				$loaded[$assetKey] = self::$assetIdByName[$assetKey];
+			}
+			// Else we have to do an extra db query to fetch it from the table fetch it from table.
+			else
+			{
+				$table = JTable::getInstance('Asset');
+				$table->load(array('name' => $assetKey));
+				$loaded[$assetKey] = $table->id;
+			}
+		}
+
+		return $loaded[$assetKey];
+	}
+
+	/**
+	 * Method to get the asset id form the asset key (id or name), using preload if already preloaded.
+	 *
+	 * @param   string  $assetKey  Asset Key (id or name).
+	 *
+	 * @return  string  Asset id.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getAssetName($assetKey)
+	{
+		static $loaded = array();
+
+		// If the asset is already a string return it.
+		if (!is_numeric($assetKey))
+		{
+			return $assetKey;
+		}
+
+		if (!isset($loaded[$assetKey]))
+		{
+			// It's the root asset.
+			if (in_array($assetKey, array(self::$rootAsset['id'], self::$rootAsset['name'])))
+			{
+				$loaded[$assetKey] = self::$rootAsset['name'];
+			}
+			// If we already have the asset name stored in preloading, example, a component, no need to fetch it from table.
+			elseif (isset(self::$assetPermissionsById[$assetKey][$assetKey]))
+			{
+				$loaded[$assetKey] = self::$assetPermissionsById[$assetKey][$assetKey]->name;
+			}
+			// Else we have to do an extra db query to fetch it from the table fetch it from table.
+			else
+			{
+				$table = JTable::getInstance('Asset');
+				$table->load($assetKey);
+				$loaded[$assetKey] = $table->name;
+			}
+		}
+
+		return $loaded[$assetKey];
+	}
+
+	/**
+	 * Method to get the extension name from the asset name.
+	 *
+	 * @param   string  $assetKey  Asset Key (id or name).
 	 *
 	 * @return  string  Extension Name.
 	 *
 	 * @since    1.6
 	 */
-	public static function getExtensionNameFromAsset($asset)
+	public static function getExtensionNameFromAsset($assetKey)
 	{
 		static $loaded = array();
 
-		if (!isset($loaded[$asset]))
+		if (!isset($loaded[$assetKey]))
 		{
-			if (is_numeric($asset))
-			{
-				$table = JTable::getInstance('Asset');
-				$table->load($asset);
-				$assetName = $table->name;
-			}
-			else
-			{
-				$assetName = $asset;
-			}
-
-			$firstDot = strpos($assetName, '.');
+			$assetName = self::getAssetName($assetKey);
+			$firstDot  = strpos($assetName, '.');
 
 			if ($assetName !== 'root.1' && $firstDot !== false)
 			{
 				$assetName = substr($assetName, 0, $firstDot);
 			}
 
-			$loaded[$asset] = $assetName;
+			$loaded[$assetKey] = $assetName;
 		}
 
-		return $loaded[$asset];
+		return $loaded[$assetKey];
 	}
 
 	/**
@@ -669,14 +909,10 @@ class JAccess
 
 		if ($asset !== 'root.1' && $lastDot !== false)
 		{
-			$assetType = substr($asset, 0, $lastDot);
-		}
-		else
-		{
-			$assetType = 'components';
+			return substr($asset, 0, $lastDot);
 		}
 
-		return $assetType;
+		return 'components';
 	}
 
 	/**

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -52,7 +52,7 @@ class JAccess
 	 */
 	protected static $assetPermissionsById = array();
 
- 	/**
+	/**
 	 * Array of permissions for an asset type
 	 * (Array Key = Asset Name)
 	 *

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -535,8 +535,8 @@ class JAccess
 		// Get the asset id and name.
 		$assetId = self::getAssetId($assetKey);
 
-		// If asset rules already cached em memory return it.
-		if ($assetId && isset(self::$assetRules[$assetId]))
+		// If asset rules already cached em memory return it (only in full recursive mode).
+		if ($recursive && $recursiveParentAsset && $assetId && isset(self::$assetRules[$assetId]))
 		{
 			return self::$assetRules[$assetId];
 		}
@@ -564,7 +564,7 @@ class JAccess
 		}
 
 		// Almost all calls can take advantage of preloading.
-		if ($recursive && $recursiveParentAsset && $assetId && isset(self::$preloadedAssets[$assetId]))
+		if ($assetId && isset(self::$preloadedAssets[$assetId]))
 		{
 			!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::getAssetRules (id:' . $assetId . ' name:' . $assetName . ')');
 
@@ -596,6 +596,12 @@ class JAccess
 						continue;
 					}
 
+					// If empty asset to not add to rules.
+					if (self::$assetPermissionsParentIdMapping[$extensionName][$id]->rules === '{}')
+					{
+						continue;
+					}
+
 					$collected[] = self::$assetPermissionsParentIdMapping[$extensionName][$id]->rules;
 				}
 			}
@@ -616,7 +622,7 @@ class JAccess
 				self::$assetRulesIdentities[$hash] = $rules;
 			}
 
-			// Only save rules if recursive.
+			// Save asset rules to memory cache(only in full recursive mode).
 			if ($recursive && $recursiveParentAsset)
 			{
 				self::$assetRules[$assetId] = self::$assetRulesIdentities[$hash];


### PR DESCRIPTION
### Summary of Changes

xxxxxxxxxxxxxxxxx



#### Performance & Memory Improvements

There a overall improve in performance (vary) and memory usage (~0.5MB less) in all pages (some less, some more).

Some tests (click for details):
<details>
<summary>Test: Frontend page logged in as Administrator</summary>

#### Before PR (3.6.4)

![image](https://cloud.githubusercontent.com/assets/9630530/20124285/45b37356-a61d-11e6-98a5-6dd1d760c886.png)

#### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/20124224/b831d018-a61c-11e6-8e33-41e19cdd927e.png)
</details>

<details>
<summary>Test: Frontend page not logged</summary>

#### Before PR (3.6.4)

![image](https://cloud.githubusercontent.com/assets/9630530/20124331/92e56648-a61d-11e6-921f-a47baf7399c3.png)

#### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/20124410/0ae25584-a61e-11e6-8beb-4948a1d9a202.png)
</details>


<details>
<summary>Test: Backend list view 100 articles logged in as Administrator</summary>

#### Before PR (3.6.4)

![image](https://cloud.githubusercontent.com/assets/9630530/20124061/9bae3dec-a61b-11e6-84fe-06b4f27752ea.png)

#### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/20124002/2bb01a2e-a61b-11e6-9ad8-cdb7704b8271.png)
</details>

<details>
<summary>Test: Backend list view 500 articles logged in as Administrator</summary>

#### Before PR (3.6.4)

![image](https://cloud.githubusercontent.com/assets/9630530/20139460/22fef3c4-a67e-11e6-87ef-1d7764f0a457.png)

#### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/20139463/26c3aaf4-a67e-11e6-8526-f463f80080ac.png)
</details>


<br/>Test notes: The total time difference an db queries times is not accurate, depends on several factors.

#### B/C

Should be B/C. But please confirm.

### Testing Instructions

xxxxxxxxxxxxxxxxx

### Documentation Changes Required

None
