### PR TITLE
Deprecates JLanguageMultilang::isEnabled(). Replaces it with JPluginHelper::isEnabled('system', 'languagefilter')

### DIFF
--- a/administrator/components/com_admin/models/profile.php
+++ b/administrator/components/com_admin/models/profile.php
@@ -58,7 +58,7 @@ class AdminModelProfile extends UsersModelUser
 		}
 
 		// When multilanguage is set, a user's default site language should also be a Content Language
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -84,7 +84,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					);
 					?>
 					<?php foreach ($this->items as $i => $item) : ?>
-						<?php if ($item->language && JLanguageMultilang::isEnabled())
+						<?php if ($item->language && JPluginHelper::isEnabled('system', 'languagefilter'))
 						{
 							$tag = strlen($item->language);
 							if ($tag == 5)
@@ -100,7 +100,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								$lang = "";
 							}
 						}
-						elseif (!JLanguageMultilang::isEnabled())
+						elseif (!JPluginHelper::isEnabled('system', 'languagefilter'))
 						{
 							$lang = "";
 						}

--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -83,7 +83,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				);
 				?>
 				<?php foreach ($this->items as $i => $item) : ?>
-					<?php if ($item->language && JLanguageMultilang::isEnabled())
+					<?php if ($item->language && JPluginHelper::isEnabled('system', 'languagefilter'))
 					{
 						$tag = strlen($item->language);
 						if ($tag == 5)
@@ -98,7 +98,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							$lang = "";
 						}
 					}
-					elseif (!JLanguageMultilang::isEnabled())
+					elseif (!JPluginHelper::isEnabled('system', 'languagefilter'))
 					{
 						$lang = "";
 					}

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -86,7 +86,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				);
 				?>
 				<?php foreach ($this->items as $i => $item) : ?>
-					<?php if ($item->language && JLanguageMultilang::isEnabled())
+					<?php if ($item->language && JPluginHelper::isEnabled('system', 'languagefilter'))
 					{
 						$tag = strlen($item->language);
 						if ($tag == 5)
@@ -101,7 +101,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							$lang = "";
 						}
 					}
-					elseif (!JLanguageMultilang::isEnabled())
+					elseif (!JPluginHelper::isEnabled('system', 'languagefilter'))
 					{
 						$lang = "";
 					}

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -84,7 +84,7 @@ class FieldsHelper
 		{
 			$item = (object) $item;
 		}
-		if (JLanguageMultilang::isEnabled() && isset($item->language) && $item->language !='*')
+		if (JPluginHelper::isEnabled('system', 'languagefilter') && isset($item->language) && $item->language !='*')
 		{
 			self::$fieldsCache->setState('filter.language', array('*', $item->language));
 		}

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -115,7 +115,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<label for="cb<?php echo $i; ?>" style="display:inline-block;">
 						<?php echo $this->escape($title); ?>
 					</label>
-					<?php if ($this->escape(trim($title, '**')) == 'Language' && JLanguageMultilang::isEnabled()) : ?>
+					<?php if ($this->escape(trim($title, '**')) == 'Language' && JPluginHelper::isEnabled('system', 'languagefilter')) : ?>
 						<strong><?php echo JText::_('COM_FINDER_MAPS_MULTILANG'); ?></strong>
 					<?php endif; ?>
 					</td>

--- a/administrator/components/com_languages/views/multilangstatus/view.html.php
+++ b/administrator/components/com_languages/views/multilangstatus/view.html.php
@@ -28,7 +28,7 @@ class LanguagesViewMultilangstatus extends JViewLegacy
 		JLoader::register('MultilangstatusHelper', JPATH_ADMINISTRATOR . '/components/com_languages/helpers/multilangstatus.php');
 
 		$this->homes           = MultilangstatusHelper::getHomes();
-		$this->language_filter = JLanguageMultilang::isEnabled();
+		$this->language_filter = JPluginHelper::isEnabled('system', 'languagefilter');
 		$this->switchers       = MultilangstatusHelper::getLangswitchers();
 		$this->listUsersError  = MultilangstatusHelper::getContacts();
 		$this->contentlangs    = MultilangstatusHelper::getContentlangs();

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -161,7 +161,7 @@ class MenusHelper
 					  a.lft')
 			->from('#__menu AS a');
 
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$query->select('l.title AS language_title, l.image AS language_image, l.sef AS language_sef')
 				->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = a.language');

--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -88,7 +88,7 @@ jQuery(document).ready(function($) {
 				<tbody>
 				<?php foreach ($this->items as $i => $item) : ?>
 					<?php if ($item->type != 'separator' && $item->type != 'alias' && $item->type != 'heading' && $item->type != 'url') : ?>
-						<?php if ($item->language && JLanguageMultilang::isEnabled())
+						<?php if ($item->language && JPluginHelper::isEnabled('system', 'languagefilter'))
 						{
 							if ($item->language !== '*')
 							{
@@ -99,7 +99,7 @@ jQuery(document).ready(function($) {
 								$language = '';
 							}
 						}
-						elseif (!JLanguageMultilang::isEnabled())
+						elseif (!JPluginHelper::isEnabled('system', 'languagefilter'))
 						{
 							$language = '';
 						}

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -113,7 +113,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 									<input type="checkbox" class="pull-left novalidate" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?> />
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
-										<?php if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*') : ?>
+										<?php if (JPluginHelper::isEnabled('system', 'languagefilter') && $link->language != '' && $link->language != '*') : ?>
 											<?php if ($link->language_image) : ?>
 												<?php echo JHtml::_('image', 'mod_languages/' . $link->language_image . '.gif', $link->language_title, array('title' => $link->language_title), true); ?>
 											<?php else : ?>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
@@ -75,7 +75,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				);
 				?>
 				<?php foreach ($this->items as $i => $item) : ?>
-					<?php if ($item->language && JLanguageMultilang::isEnabled())
+					<?php if ($item->language && JPluginHelper::isEnabled('system', 'languagefilter'))
 					{
 						$tag = strlen($item->language);
 						if ($tag == 5)
@@ -90,7 +90,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							$lang = "";
 						}
 					}
-					elseif (!JLanguageMultilang::isEnabled())
+					elseif (!JPluginHelper::isEnabled('system', 'languagefilter'))
 					{
 						$lang = "";
 					}

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -130,7 +130,7 @@ class UsersModelUser extends JModelAdmin
 		}
 
 		// When multilanguage is set, a user's default site language should also be a Content Language
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}

--- a/administrator/templates/hathor/html/layouts/joomla/edit/details.php
+++ b/administrator/templates/hathor/html/layouts/joomla/edit/details.php
@@ -68,7 +68,7 @@ $saveHistory = $displayData->get('state')->get('params')->get('save_history', 0)
 						<?php echo $displayData->get('form')->getInput('featured'); ?>
 					</div>
 				</div>
-				<?php if (JLanguageMultilang::isEnabled()) : ?>
+				<?php if (JPluginHelper::isEnabled('system', 'languagefilter')) : ?>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $displayData->get('form')->getLabel('language'); ?>

--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -18,7 +18,7 @@ JHtml::_('formbehavior.chosen', 'select');
 $hasContent = empty($this->item['module']) || $this->item['module'] == 'custom' || $this->item['module'] == 'mod_custom';
 
 // If multi-language site, make language read-only
-if (JLanguageMultilang::isEnabled())
+if (JPluginHelper::isEnabled('system', 'languagefilter'))
 {
 	$this->form->setFieldAttribute('language', 'readonly', 'true');
 }

--- a/components/com_config/view/modules/tmpl/default_options.php
+++ b/components/com_config/view/modules/tmpl/default_options.php
@@ -37,7 +37,7 @@ endif;
 			<div class="controls">
 				<?php
 				// If multi-language site, make menu-type selection read-only
-				if (JLanguageMultilang::isEnabled() && $this->item['module'] == 'mod_menu' && $field->getAttribute('name') == 'menutype')
+				if (JPluginHelper::isEnabled('system', 'languagefilter') && $this->item['module'] == 'mod_menu' && $field->getAttribute('name') == 'menutype')
 				{
 					$field->__set('readonly', true);
 				}

--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -40,7 +40,7 @@ abstract class ContactHelperRoute
 			$link .= '&catid=' . $catid;
 		}
 
-		if ($language && $language !== '*' && JLanguageMultilang::isEnabled())
+		if ($language && $language !== '*' && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$link .= '&lang=' . $language;
 		}
@@ -78,7 +78,7 @@ abstract class ContactHelperRoute
 			// Create the link
 			$link = 'index.php?option=com_contact&view=category&id=' . $id;
 
-			if ($language && $language !== '*' && JLanguageMultilang::isEnabled())
+			if ($language && $language !== '*' && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$link .= '&lang=' . $language;
 			}

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -291,7 +291,7 @@ class ContactModelCategory extends JModelList
 			$this->setState('filter.publish_date', true);
 		}
 
-		$this->setState('filter.language', JLanguageMultilang::isEnabled());
+		$this->setState('filter.language', JPluginHelper::isEnabled('system', 'languagefilter'));
 
 		// Load the parameters.
 		$this->setState('params', $params);

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -316,7 +316,7 @@ class ContactModelContact extends JModelForm
 				->order('a.state DESC, a.created DESC');
 
 			// Filter per language if plugin published
-			if (JLanguageMultilang::isEnabled())
+			if (JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$query->where(
 					('a.created_by = ' . (int) $contact->user_id) . ' AND ' .
@@ -501,7 +501,7 @@ class ContactModelContact extends JModelForm
 						->order('a.state DESC, a.created DESC');
 
 					// Filter per language if plugin published
-					if (JLanguageMultilang::isEnabled())
+					if (JPluginHelper::isEnabled('system', 'languagefilter'))
 					{
 						$query->where('a.language IN (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 					}

--- a/components/com_contact/models/featured.php
+++ b/components/com_contact/models/featured.php
@@ -249,7 +249,7 @@ class ContactModelFeatured extends JModelList
 			$this->setState('filter.publish_date', true);
 		}
 
-		$this->setState('filter.language', JLanguageMultilang::isEnabled());
+		$this->setState('filter.language', JPluginHelper::isEnabled('system', 'languagefilter'));
 
 		// Load the parameters.
 		$this->setState('params', $params);

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -37,7 +37,7 @@ abstract class ContentHelperRoute
 			$link .= '&catid=' . $catid;
 		}
 
-		if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+		if ($language && $language != "*" && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$link .= '&lang=' . $language;
 		}
@@ -74,7 +74,7 @@ abstract class ContentHelperRoute
 		{
 			$link = 'index.php?option=com_content&view=category&id=' . $id;
 
-			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+			if ($language && $language != "*" && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$link .= '&lang=' . $language;
 			}

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -58,7 +58,7 @@ class ContentModelArticle extends JModelItem
 			$this->setState('filter.archived', 2);
 		}
 
-		$this->setState('filter.language', JLanguageMultilang::isEnabled());
+		$this->setState('filter.language', JPluginHelper::isEnabled('system', 'languagefilter'));
 	}
 
 	/**

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -116,7 +116,7 @@ class ContentModelArticles extends JModelList
 			$this->setState('filter.published', 1);
 		}
 
-		$this->setState('filter.language', JLanguageMultilang::isEnabled());
+		$this->setState('filter.language', JPluginHelper::isEnabled('system', 'languagefilter'));
 
 		// Process show_noauth parameter
 		if (!$params->get('show_noauth'))

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -208,7 +208,7 @@ class ContentModelCategory extends JModelList
 			$this->setState('filter.subcategories', true);
 		}
 
-		$this->setState('filter.language', JLanguageMultilang::isEnabled());
+		$this->setState('filter.language', JPluginHelper::isEnabled('system', 'languagefilter'));
 
 		$this->setState('layout', $app->input->getString('layout'));
 

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -112,7 +112,7 @@ class ContentViewForm extends JViewLegacy
 		}
 
 		// Propose current language as default when creating new article
-		if (JLanguageMultilang::isEnabled() && empty($this->item->id))
+		if (JPluginHelper::isEnabled('system', 'languagefilter') && empty($this->item->id))
 		{
 			$lang = JFactory::getLanguage()->getTag();
 			$this->form->setFieldAttribute('language', 'default', $lang);

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -116,7 +116,7 @@ abstract class JHtmlFilter
 		foreach ($branches as $bk => $bv)
 		{
 			// If the multi-lang plugin is enabled then drop the language branch.
-			if ($bv->title == 'Language' && JLanguageMultilang::isEnabled())
+			if ($bv->title == 'Language' && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				continue;
 			}
@@ -298,7 +298,7 @@ abstract class JHtmlFilter
 			foreach ($branches as $bk => $bv)
 			{
 				// If the multi-lang plugin is enabled then drop the language branch.
-				if ($bv->title == 'Language' && JLanguageMultilang::isEnabled())
+				if ($bv->title == 'Language' && JPluginHelper::isEnabled('system', 'languagefilter'))
 				{
 					continue;
 				}
@@ -371,7 +371,7 @@ abstract class JHtmlFilter
 		foreach ($branches as $bk => $bv)
 		{
 			// If the multi-lang plugin is enabled then drop the language branch.
-			if ($bv->title == 'Language' && JLanguageMultilang::isEnabled())
+			if ($bv->title == 'Language' && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				continue;
 			}

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1050,7 +1050,7 @@ class FinderModelSearch extends JModelList
 		$user = JFactory::getUser();
 		$filter = JFilterInput::getInstance();
 
-		$this->setState('filter.language', JLanguageMultilang::isEnabled());
+		$this->setState('filter.language', JPluginHelper::isEnabled('system', 'languagefilter'));
 
 		// Setup the stemmer.
 		if ($params->get('stem', 1) && $params->get('stemmer', 'porter_en'))

--- a/components/com_finder/models/suggestions.php
+++ b/components/com_finder/models/suggestions.php
@@ -121,7 +121,7 @@ class FinderModelSuggestions extends JModelList
 		$this->setState('input', $input->request->get('q', '', 'string'));
 
 		// Set the query language
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$lang = JFactory::getLanguage()->getTag();
 		}

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -35,7 +35,7 @@ abstract class NewsfeedsHelperRoute
 			$link .= '&catid=' . $catid;
 		}
 
-		if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+		if ($language && $language != "*" && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$link .= '&lang=' . $language;
 		}
@@ -71,7 +71,7 @@ abstract class NewsfeedsHelperRoute
 			// Create the link
 			$link = 'index.php?option=com_newsfeeds&view=category&id=' . $id;
 
-			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+			if ($language && $language != "*" && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$link .= '&lang=' . $language;
 			}

--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -235,7 +235,7 @@ class NewsfeedsModelCategory extends JModelList
 			$this->setState('filter.publish_date', true);
 		}
 
-		$this->setState('filter.language', JLanguageMultilang::isEnabled());
+		$this->setState('filter.language', JPluginHelper::isEnabled('system', 'languagefilter'));
 
 		// Load the parameters.
 		$this->setState('params', $params);

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -44,7 +44,7 @@ class UsersControllerUser extends UsersController
 		// Check for a simple menu item id
 		if (is_numeric($data['return']))
 		{
-			if (JLanguageMultilang::isEnabled())
+			if (JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 
 				$db = JFactory::getDbo();
@@ -164,7 +164,7 @@ class UsersControllerUser extends UsersController
 		// Check for a simple menu item id
 		if (is_numeric($return))
 		{
-			if (JLanguageMultilang::isEnabled())
+			if (JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 
 				$db = JFactory::getDbo();
@@ -228,7 +228,7 @@ class UsersControllerUser extends UsersController
 		$itemid = $app->getMenu()->getActive()->params->get('logout');
 
 		// Get the language of the page when multilang is on
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			if ($itemid)
 			{

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -220,7 +220,7 @@ class UsersModelProfile extends JModelForm
 		}
 
 		// When multilanguage is set, a user's default site language should also be a Content Language
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -296,7 +296,7 @@ class UsersModelRegistration extends JModelForm
 		$form = $this->loadForm('com_users.registration', 'registration', array('control' => 'jform', 'load_data' => $loadData));
 
 		// When multilanguage is set, a user's default site language should also be a Content Language
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
 		}

--- a/layouts/joomla/edit/details.php
+++ b/layouts/joomla/edit/details.php
@@ -44,7 +44,7 @@ $saveHistory = $displayData->get('state')->get('params')->get('save_history', 0)
 
 		<?php echo $displayData->getForm()->renderField('access'); ?>
 		<?php echo $displayData->getForm()->renderField('featured'); ?>
-		<?php if (JLanguageMultilang::isEnabled()) : ?>
+		<?php if (JPluginHelper::isEnabled('system', 'languagefilter')) : ?>
 			<?php echo $displayData->getForm()->renderField('language'); ?>
 		<?php else : ?>
 			<input type="hidden" id="jform_language" name="jform[language]" value="<?php echo $displayData->getForm()->getValue('language'); ?>" />

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -119,7 +119,7 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 		$active = $this->router->menu->getActive();
 
 		if ($active && $active->component == 'com_' . $this->router->getName()
-			&& ($language == '*' || in_array($active->language, array('*', $language)) || !JLanguageMultilang::isEnabled()))
+			&& ($language == '*' || in_array($active->language, array('*', $language)) || !JPluginHelper::isEnabled('system', 'languagefilter')))
 		{
 			$query['Itemid'] = $active->id;
 			return;

--- a/libraries/cms/helper/route.php
+++ b/libraries/cms/helper/route.php
@@ -104,7 +104,7 @@ class JHelperRoute
 		}
 
 		// Deal with languages only if needed
-		if (!empty($language) && $language != '*' && JLanguageMultilang::isEnabled())
+		if (!empty($language) && $language != '*' && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$link .= '&lang=' . $language;
 			$needles['language'] = $language;
@@ -208,7 +208,7 @@ class JHelperRoute
 
 		$active = $menus->getActive();
 
-		if ($active && $active->component == $this->extension && ($active->language == '*' || !JLanguageMultilang::isEnabled()))
+		if ($active && $active->component == $this->extension && ($active->language == '*' || !JPluginHelper::isEnabled('system', 'languagefilter')))
 		{
 			return $active->id;
 		}
@@ -264,7 +264,7 @@ class JHelperRoute
 				'category' => array($id),
 			);
 
-			if ($language && $language != '*' && JLanguageMultilang::isEnabled())
+			if ($language && $language != '*' && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$link .= '&lang=' . $language;
 				$needles['language'] = $language;

--- a/libraries/cms/language/associations.php
+++ b/libraries/cms/language/associations.php
@@ -137,7 +137,7 @@ class JLanguageAssociations
 		// Status of language filter parameter.
 		static $enabled = false;
 
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			// If already tested, don't test again.
 			if (!$tested)

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -23,9 +23,12 @@ class JLanguageMultilang
 	 * @return  boolean  True if site is supporting multiple languages; false otherwise.
 	 *
 	 * @since   2.5.4
+	 * @deprecated   __DEPLOY_VERSION__ Use JPluginHelper::isEnabled('system', 'languagefilter') instead.
 	 */
 	public static function isEnabled()
 	{
+		JLog::add(__METHOD__ . '() is deprecated. Use JPluginHelper::isEnabled('system', 'languagefilter') instead.', JLog::WARNING, 'deprecated');
+
 		// Flag to avoid doing multiple database queries.
 		static $tested = false;
 

--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -27,7 +27,7 @@ class JLanguageMultilang
 	 */
 	public static function isEnabled()
 	{
-		JLog::add(__METHOD__ . '() is deprecated. Use JPluginHelper::isEnabled('system', 'languagefilter') instead.', JLog::WARNING, 'deprecated');
+		JLog::add(__METHOD__ . '() is deprecated. Use JPluginHelper::isEnabled(\'system\', \'languagefilter\') instead.', JLog::WARNING, 'deprecated');
 
 		// Flag to avoid doing multiple database queries.
 		static $tested = false;

--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -150,7 +150,7 @@ class JMenuSite extends JMenu
 			// Filter by language if not set
 			if (($key = array_search('language', $attributes)) === false)
 			{
-				if (JLanguageMultilang::isEnabled())
+				if (JPluginHelper::isEnabled('system', 'languagefilter'))
 				{
 					$attributes[] = 'language';
 					$values[]     = array(JFactory::getLanguage()->getTag(), '*');

--- a/libraries/cms/pathway/site.php
+++ b/libraries/cms/pathway/site.php
@@ -36,7 +36,7 @@ class JPathwaySite extends JPathway
 			$menus = $menu->getMenu();
 
 			// Look for the home menu
-			if (JLanguageMultilang::isEnabled())
+			if (JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$home = $menu->getDefault($lang->getTag());
 			}

--- a/libraries/joomla/form/abstractlist.php
+++ b/libraries/joomla/form/abstractlist.php
@@ -99,7 +99,7 @@ abstract class JFormAbstractlist extends JFormField
 			if ($requires = explode(',', (string) $option['requires']))
 			{
 				// Requires multilanguage
-				if (in_array('multilanguage', $requires) && !JLanguageMultilang::isEnabled())
+				if (in_array('multilanguage', $requires) && !JPluginHelper::isEnabled('system', 'languagefilter'))
 				{
 					continue;
 				}

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -107,7 +107,7 @@ class JCategories
 		$options['access'] = (isset($options['access'])) ? $options['access'] : 'true';
 		$options['published'] = (isset($options['published'])) ? $options['published'] : 1;
 		$options['countItems'] = (isset($options['countItems'])) ? $options['countItems'] : 0;
-		$options['currentlang'] = JLanguageMultilang::isEnabled() ? JFactory::getLanguage()->getTag() : 0;
+		$options['currentlang'] = JPluginHelper::isEnabled('system', 'languagefilter') ? JFactory::getLanguage()->getTag() : 0;
 		$this->_options = $options;
 
 		return true;
@@ -257,7 +257,7 @@ class JCategories
 			// Get the selected category
 			$query->where('s.id=' . (int) $id);
 
-			if ($app->isSite() && JLanguageMultilang::isEnabled())
+			if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$query->join('LEFT', '#__categories AS s ON (s.lft < c.lft AND s.rgt > c.rgt AND c.language in (' . $db->quote(JFactory::getLanguage()->getTag())
 					. ',' . $db->quote('*') . ')) OR (s.lft >= c.lft AND s.rgt <= c.rgt)');
@@ -269,7 +269,7 @@ class JCategories
 		}
 		else
 		{
-			if ($app->isSite() && JLanguageMultilang::isEnabled())
+			if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$query->where('c.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 			}

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -177,7 +177,7 @@ class JTableMenu extends JTableNested
 			$error      = false;
 
 			// Check if the alias already exists. For multilingual site.
-			if (JLanguageMultilang::isEnabled())
+			if (JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				// If not exists a menu item at the same level with the same alias (in the All or the same language).
 				if (($table->load(array_replace($itemSearch, array('language' => '*'))) && ($table->id != $this->id || $this->id == 0))

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -35,7 +35,7 @@ class ModBreadCrumbsHelper
 		$menu    = $app->getMenu();
 
 		// Look for the home menu
-		if (JLanguageMultilang::isEnabled())
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$home = $menu->getDefault($lang->getTag());
 		}

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -74,7 +74,7 @@ abstract class ModLanguagesHelper
 
 		$levels    = $user->getAuthorisedViewLevels();
 		$sitelangs = JLanguageHelper::getInstalledLanguages(0);
-		$multilang = JLanguageMultilang::isEnabled();
+		$multilang = JPluginHelper::isEnabled('system', 'languagefilter');
 
 		// Filter allowed languages
 		foreach ($languages as $i => &$language)

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -39,7 +39,7 @@ class ModLoginHelper
 		{
 			$lang = '';
 
-			if (JLanguageMultilang::isEnabled() && $item->language !== '*')
+			if (JPluginHelper::isEnabled('system', 'languagefilter') && $item->language !== '*')
 			{
 				$lang = '&lang=' . $item->language;
 			}

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -138,7 +138,7 @@ abstract class ModRelatedItemsHelper
 					->where('(a.publish_down = ' . $db->quote($nullDate) . ' OR a.publish_down >= ' . $db->quote($now) . ')');
 
 				// Filter by language
-				if (JLanguageMultilang::isEnabled())
+				if (JPluginHelper::isEnabled('system', 'languagefilter'))
 				{
 					$query->where('a.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 				}

--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -96,7 +96,7 @@ class PlgContentContact extends JPlugin
 		$query->where('contact.published = 1');
 		$query->where('contact.user_id = ' . (int) $created_by);
 
-		if (JLanguageMultilang::isEnabled() == 1)
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$query->where('(contact.language in '
 				. '(' . $this->db->quote(JFactory::getLanguage()->getTag()) . ',' . $this->db->quote('*') . ') '

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -163,7 +163,7 @@ class PlgSearchCategories extends JPlugin
 			->group('a.id, a.title, a.description, a.alias, a.created_time')
 			->order($order);
 
-		if ($app->isSite() && JLanguageMultilang::isEnabled())
+		if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$query->where('a.language in (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 		}

--- a/plugins/search/contacts/contacts.php
+++ b/plugins/search/contacts/contacts.php
@@ -158,7 +158,7 @@ class PlgSearchContacts extends JPlugin
 			->order($order);
 
 		// Filter by language.
-		if ($app->isSite() && JLanguageMultilang::isEnabled())
+		if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$tag = JFactory::getLanguage()->getTag();
 			$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -187,7 +187,7 @@ class PlgSearchContent extends JPlugin
 				->order($order);
 
 			// Filter by language.
-			if ($app->isSite() && JLanguageMultilang::isEnabled())
+			if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')
 					->where('c.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')
@@ -262,7 +262,7 @@ class PlgSearchContent extends JPlugin
 				->order($order);
 
 			// Filter by language.
-			if ($app->isSite() && JLanguageMultilang::isEnabled())
+			if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 			{
 				$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')
 					->where('c.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')

--- a/plugins/search/newsfeeds/newsfeeds.php
+++ b/plugins/search/newsfeeds/newsfeeds.php
@@ -173,7 +173,7 @@ class PlgSearchNewsfeeds extends JPlugin
 			->order($order);
 
 		// Filter by language.
-		if ($app->isSite() && JLanguageMultilang::isEnabled())
+		if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$tag = JFactory::getLanguage()->getTag();
 			$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')

--- a/plugins/search/tags/tags.php
+++ b/plugins/search/tags/tags.php
@@ -129,7 +129,7 @@ class PlgSearchTags extends JPlugin
 			$query->where('a.access IN (' . $groups . ')');
 		}
 
-		if ($app->isSite() && JLanguageMultilang::isEnabled())
+		if ($app->isSite() && JPluginHelper::isEnabled('system', 'languagefilter'))
 		{
 			$tag = JFactory::getLanguage()->getTag();
 			$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')');


### PR DESCRIPTION
### Summary of Changes

Deprecates `JLanguageMultilang::isEnabled()` in favour of `JPluginHelper::isEnabled('system', 'languagefilter')` (like all other plugins) and replaces the deprected method in all code base.

### Testing Instructions

1. Code review
2. Use latest staging, apply patch and joomla language works as before.

### Documentation Changes Required

None.