### PR TITLE
[JLanguage] Save language variable overrides with escaped double quotes (instead of _QQ_)

### DIFF
--- a/administrator/components/com_languages/models/override.php
+++ b/administrator/components/com_languages/models/override.php
@@ -179,16 +179,8 @@ class LanguagesModelOverride extends JModelAdmin
 			$strings = array($data['key'] => $data['override']) + $strings;
 		}
 
-		foreach ($strings as $key => $string)
-		{
-			$strings[$key] = str_replace('"', '"_QQ_"', $string);
-		}
-
 		// Write override.ini file with the strings.
-		$registry = new Registry($strings);
-		$reg = $registry->toString('INI');
-
-		if (!JFile::write($filename, $reg))
+		if (JLanguageHelper::saveToIniFile($filename, $strings) === false)
 		{
 			return false;
 		}

--- a/administrator/components/com_languages/models/override.php
+++ b/administrator/components/com_languages/models/override.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Registry\Registry;
-
 /**
  * Languages Override Model
  *

--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Registry\Registry;
-
 /**
  * Languages Overrides Model
  *

--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -265,18 +265,8 @@ class LanguagesModelOverrides extends JModelList
 			}
 		}
 
-		foreach ($strings as $key => $string)
-		{
-			$strings[$key] = str_replace('"', '"_QQ_"', $string);
-		}
-
-		// Write override.ini file with the left strings.
-		$registry = new Registry($strings);
-		$reg = $registry->toString('INI');
-
-		$filename = constant('JPATH_' . $client) . '/language/overrides/' . $this->getState('filter.language') . '.override.ini';
-
-		if (!JFile::write($filename, $reg))
+		// Write override.ini file with the strings.
+		if (JLanguageHelper::saveToIniFile($filename, $strings) === false)
 		{
 			return false;
 		}

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -402,7 +402,7 @@ class JLanguageHelper
 		}
 
 		// Write override.ini file with the strings.
-		$registry = new Registry($strings);
+		$registry = new Joomla\Registry\Registry($strings);
 
 		return JFile::write($filename, $registry->toString('INI'));
 	}

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -380,4 +380,30 @@ class JLanguageHelper
 
 		return $languages;
 	}
+
+	/**
+	 * Save strings to a language file.
+	 *
+	 * @param   string  $filename  The language ini file path.
+	 * @param   array   $strings   The array of strings.
+	 *
+	 * @return  boolean  True if saved, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function saveToIniFile($filename, array $strings)
+	{
+		JLoader::register('JFile', JPATH_LIBRARIES . '/joomla/filesystem/file.php');
+
+		// Escape double quotes.
+		foreach ($strings as $key => $string)
+		{
+			$strings[$key] = addcslashes($string, '"');
+		}
+
+		// Write override.ini file with the strings.
+		$registry = new Registry($strings);
+
+		return JFile::write($filename, $registry->toString('INI'));
+	}
 }


### PR DESCRIPTION
### Summary of Changes

This PR changes language overrides save to ini method so we use escaped double quotes (`\"`) with of `"_QQ_"`.
Also adds a new method to save the language strings to a ini file so it can be easily used when needed.

### Testing Instructions

- Apply patch
- Create a new language override from Extensions -> Languages -> Overrides for the en-GB admin language with some double quotes on it (`"`). Save it, load it again and confirm if ok.
- Confirm it's saved as escaped double quote in `/administrator/language/overrides/en-GB.override.ini`.  Example: `A test with <a href=\"https://joomla.org\" target=\"_blank\">Joomla</a>`
- Manually add an override in `/administrator/language/overrides/en-GB.override.ini` with `_QQ_` and escaped quotes. Example:
```ini
JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED="A second test with <a href="_QQ_"https://joomla.org"_QQ_" target=\"_blank\">Joomla</a>"
```
- Confirm language override works
Ex: add to template index.php
```php
// Server side message system
$app->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'warning');

// Client side message system (click on the page to test the javascript message)
JText::script('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED');
$this->addScriptDeclaration("window.addEventListener('click', function () { Joomla.renderMessages({'error': [Joomla.JText._('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED')]}) });");

```
- Any other test you could remember

### Documentation Changes Required

None.