### PR TITLE
Improve performance ModuleHelper getLayoutPath

### DIFF
--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -290,6 +290,15 @@ abstract class ModuleHelper
 	 */
 	public static function getLayoutPath($module, $layout = 'default')
 	{
+		static $paths = array();
+
+		$cacheKey = $module . $layout;
+
+		if (isset($paths[$cacheKey]))
+		{
+			return $paths[$cacheKey];
+		}
+
 		$template = \JFactory::getApplication()->getTemplate();
 		$defaultLayout = $layout;
 
@@ -310,15 +319,21 @@ abstract class ModuleHelper
 		// If the template has a layout override use it
 		if (file_exists($tPath))
 		{
-			return $tPath;
+			$paths[$cacheKey] = $tPath;
+
+			return $paths[$cacheKey];
 		}
 
 		if (file_exists($bPath))
 		{
-			return $bPath;
+			$paths[$cacheKey] = $bPath;
+
+			return $paths[$cacheKey];
 		}
 
-		return $dPath;
+		$paths[$cacheKey] = $dPath;
+
+		return $paths[$cacheKey];
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Improve performance of ModuleHelper getLayoutPath.

### Testing Instructions

1. Test performance, across all modules that repeat layouts, but let's use mod_menu (which repeat the default_component.php layout a lot).
Replace in /modules/mod_menu/mod_menu.php.
```php
require JModuleHelper::getLayoutPath('mod_menu', $params->get('layout', 'default'));
```

for
```php
$start = microtime(true);
require JModuleHelper::getLayoutPath('mod_menu', $params->get('layout', 'default'));
echo number_format(((microtime(true) - $start) * 1000), 3) . ' ms' . PHP_EOL;
```

My results:

| Menu items  | Before | After |
| --- | --- | --- |
| 10 | 2.251 ms | 1.525 ms |
| 50  | 8.911 ms | 4.977 ms |
| 100 | 16.985 ms | 9.288 ms |

2. Test if modules still render fine.

### Expected result

Faster rendering modules that call the same layouts over and over inside cycles (ex: mod_menu default_url layout). Particulary on systems with php "open_basedir" configuration enabled.

### Actual result

Always calculating the module layout path that was already found before.

### Documentation Changes Required

None.