### PR TITLE
solve database double timeout error issue

### DIFF
--- a/libraries/joomla/session/handler/joomla.php
+++ b/libraries/joomla/session/handler/joomla.php
@@ -74,7 +74,7 @@ class JSessionHandlerJoomla extends JSessionHandlerNative
 		// Get the JInputCookie object
 		$cookie = $this->input->cookie;
 
-		if (is_null($cookie->get($session_name)))
+		if (is_null($cookie->exists($session_name)))
 		{
 			$session_clean = $this->input->get($session_name, false, 'string');
 

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -49,7 +49,7 @@ abstract class JSessionStorage
 	 */
 	public static function getInstance($name = 'none', $options = array())
 	{
-		$name = strtolower(JFilterInput::getInstance()->clean($name, 'word'));
+		$name = preg_replace('#[^a-z_]#', '', strtolower($name));
 
 		if (empty(self::$instances[$name]))
 		{

--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -63,14 +63,14 @@ class InputFilter extends BaseInputFilter
 		 */
 		if ($this->stripUSC === -1)
 		{
+			// Get the database driver
+			$db = \JFactory::getDbo();
+
+			// This trick is required to let the driver determine the utf-8 multibyte support
+			$db->connect();
+
 			try
 			{
-				// Get the database driver
-				$db = \JFactory::getDbo();
-
-				// This trick is required to let the driver determine the utf-8 multibyte support
-				$db->connect();
-
 				// And now we can decide if we should strip USCs
 				$this->stripUSC = $db->hasUTF8mb4Support() ? 0 : 1;
 			}

--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -33,6 +33,15 @@ class InputFilter extends BaseInputFilter
 	public $stripUSC = 0;
 
 	/**
+	 * Flag to identify if database was already checked for Unicode Supplementary Characters (4-byte Unicode character).
+	 *
+	 * @var    boolean
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $UTF8mb4SupportChecked = false;
+
+	/**
 	 * Constructor for inputFilter class. Only first parameter is required.
 	 *
 	 * @param   array    $tagsArray   List of user-defined tags
@@ -115,16 +124,14 @@ class InputFilter extends BaseInputFilter
 	 */
 	public function clean($source, $type = 'string')
 	{
-		static $stripUSCChecked = false;
-
 		/**
 		 * If Unicode Supplementary Characters stripping is not set we have to check with the database driver. If the
 		 * driver does not support USCs (i.e. there is no utf8mb4 support) we will enable USC stripping.
 		 * Lasy load this on clean method so the application doesn't the depend on the database to instanciate.
 		 */
-		if ($stripUSCChecked === false && $this->stripUSC === -1)
+		if ($this->UTF8mb4SupportChecked === false && $this->stripUSC === -1)
 		{
-			$stripUSCChecked = true;
+			$this->UTF8mb4SupportChecked = true;
 
 			try
 			{

--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -33,7 +33,7 @@ class InputFilter extends BaseInputFilter
 	public $stripUSC = 0;
 
 	/**
-	 * Flag to identify if database was already checked for Unicode Supplementary Characters (4-byte Unicode character).
+	 * Flag to identify if the database was checked for Unicode Supplementary Characters (4-byte Unicode character) support.
 	 *
 	 * @var    boolean
 	 *


### PR DESCRIPTION
Because InputFilter class is cathing all (!) database exceptions, when there is database connection error the erro message is not correct and jooml makes two loops to reach the socket timeout and send an error to the client.
This is valid for database configurarion errors, network connection issues, etc, all sort of issues when there is databse connection issues.

### Steps to reproduce the issue

1. Set the php default_socket_timeout to 5 seconds in php.ini (default is 60 seconds), this is for making tests faster
```ini
default_socket_timeout = 5
```

2. Now change your databse host in configuration.php file to an unexistent hosts (ex 128.0.0.1) and make sure session handler is set to database
```php
	public $host = '128.0.0.1';
	// [...]
	public $session_handler = 'database';
```

3. Now refresh the page. You will notice the error only happens after 10 seconds (not 5 as in default_socket_timeout)

4. Now apply this PR code

5. Now refresh the page. You will notice the error only happens after 5 seconds (as in default_socket_timeout)

### Expected result

- Only wait for the socket timeout when database coonection fails

### Actual result

- Double the wait for the socket timeout when database coonection fails

### System information (as much as possible)

Joomla latest version

### Additional comments

Because the InputFilter class instanciate is being called before the session starts and the InputFilter class is making an database connection attempt that when fails is ignored, when database connection failure joomla is making two timeout loops, so it doubles the time to respond to the client, that is, by PHP default 60 seconds (so the double is 120 seconds).